### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/pytim/itim.py
+++ b/pytim/itim.py
@@ -237,7 +237,7 @@ class ITIM(pytim.PYTIM):
         try:
             np.arange(int(self.alpha/self.target_mesh))
         except:
-            print("Error while initializing ITIM: alpha (%f) too large or mesh (%f) too small" % self.alpha,self.target_mesh)
+            print("Error while initializing ITIM: alpha ({0:f}) too large or mesh ({1:f}) too small".format(*self.alpha),self.target_mesh)
             raise ValueError
 
 

--- a/pytim/wc.py
+++ b/pytim/wc.py
@@ -213,7 +213,7 @@ class WC(pytim.PYTIM):
         try:
             np.arange(int(self.alpha/self.target_mesh))
         except:
-            print("Error while initializing ITIM: alpha (%f) too large or mesh (%f) too small" % self.alpha,self.target_mesh)
+            print("Error while initializing ITIM: alpha ({0:f}) too large or mesh ({1:f}) too small".format(*self.alpha),self.target_mesh)
             raise ValueError
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:Marcello-Sega:pytim?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:Marcello-Sega:pytim?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)