### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/pytim/gitim.py
+++ b/pytim/gitim.py
@@ -315,7 +315,7 @@ class GITIM(pytim.PYTIM):
         return self.surface_triangulation
 
     def _initialize_distance_interpolator(self,layer):
-        if self._interpolator == None :
+        if self._interpolator is None :
             # we don't know if previous triangulations have been done on the same
             # layer, so just in case we repeat it here. This can be fixed in principle
             # with a switch

--- a/pytim/itim.py
+++ b/pytim/itim.py
@@ -214,7 +214,7 @@ class ITIM(pytim.PYTIM):
 
                     _layers.append(_inlayer_group)
                     break
-        if(queue==None):
+        if(queue is None):
             return _layers
         else:
             queue.put(_layers)
@@ -378,7 +378,7 @@ class ITIM(pytim.PYTIM):
         return self.surface_triangulation
 
     def _initialize_distance_interpolator(self,layer):
-        if self._interpolator == None :
+        if self._interpolator is None :
             # we don't know if previous triangulations have been done on the same
             # layer, so just in case we repeat it here. This can be fixed in principle
             # with a switch

--- a/pytim/observables.py
+++ b/pytim/observables.py
@@ -609,10 +609,10 @@ class Profile(object):
         # Statistics will be poor at the boundaries, but like that we don't loose information
         _max_bins  = np.max(map(lambda x: len(x),self.sampled_bins))
         _max_size  = _max_bins * self.binsize
-        if(binwidth==None and nbins==None):
+        if(binwidth is None and nbins is None):
             _nbins = _max_bins
         else:
-            if binwidth==None:
+            if binwidth is None:
                 _nbins = nbins
             else:
                 _nbins = _max_size/binwidth

--- a/pytim/wc.py
+++ b/pytim/wc.py
@@ -190,7 +190,7 @@ class WC(pytim.PYTIM):
 
                     _layers.append(_inlayer_group)
                     break
-        if(queue==None):
+        if(queue is None):
             return _layers
         else:
             queue.put(_layers)
@@ -352,7 +352,7 @@ class WC(pytim.PYTIM):
         return self.surface_triangulation
 
     def _initialize_distance_interpolator(self,layer):
-        if self._interpolator == None :
+        if self._interpolator is None :
             # we don't know if previous triangulations have been done on the same
             # layer, so just in case we repeat it here. This can be fixed in principle
             # with a switch

--- a/st-dist.py
+++ b/st-dist.py
@@ -73,7 +73,7 @@ with md.Writer(pdbtrj, multiframe=True, bonds=False, n_atoms=u.atoms.n_atoms) as
 			exit()
 		X, Y = np.meshgrid(Tedge[0:-1], Pedge[0:-1])
 		if do_plot:
-			if image==None:
+			if image is None:
 				norm = cm.colors.Normalize(vmax=abs(H).max(), vmin=-abs(H).max())
 				#image = plt.imshow(H, interpolation='nearest', origin='low',extent=[Tedge[0], Tedge[-1], Pedge[0], Pedge[-1]],animated=True)
 				plt.draw()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:Marcello-Sega:pytim?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:Marcello-Sega:pytim?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)