### PR TITLE
Update __init__.py

### DIFF
--- a/pytim/__init__.py
+++ b/pytim/__init__.py
@@ -519,7 +519,7 @@ class PYTIM(object):
         """
         self.writepdb(filename, centered, multiframe)
 
-    def _define_cluster_group(self):
+    def _define_cluster_group(self, extra_cluster_groups=None):
         if(self.cluster_cut is not None):
             # groups have been checked already in _sanity_checks()
             labels, counts, neighbors = utilities.do_cluster_analysis_DBSCAN(
@@ -532,8 +532,12 @@ class PYTIM(object):
             # the indices (within the group) of the
             ids_max = np.where(labels == label_max)[0]
             # atoms belonging to the largest cluster
-            self.cluster_group = self.itim_group[ids_max]
-            self.n_neighbors = neighbors
+            if (extra_cluster_groups is not None) :
+                self.cluster_group = self.itim_group[ids_max] + extra_cluster_groups
+                self.n_neighbors = neighbors # I don't fully see yet but I guess this is not so simple. one has take into account some of the neighbors of extra_cluster_groups... ?
+            else :
+                self.cluster_group = self.itim_group[ids_max]
+                self.n_neighbors = neighbors
         else:
             self.cluster_group = self.itim_group
 


### PR DESCRIPTION
Did some modifications to _define_cluster_group() to take into account dissolved clusters of the other (not fully mixing) compound. 

However, I am a little stuck here... I have the impression the problem is a bit more complex than we thought, because
-the cluster_search / DBScan  has to be performed for **both compounds**. Cluster_group has to be the union of the largest cluster and the extra_cluster_groups of the other phase (if I understood correctly the meaning of this parameter);
-the largest cluster is determined in _define_cluster_group and consequently extra_cluster_groups should be determined in this function too.

Originally I wanted to modify do_cluster_analysis_DBSCAN() in utilities.py too, but this is not how it should be done.

So what I would do is the following (if I understood correctly what the functions do):
-before defining cluster_group I would perform DBScan, maybe in a separate function, on both compounds and store i) particles in the largest cluster and ii) all other particles in all other clusters (extra_cluster_groups) **for both compounds**.
-once this is done, I would determine cluster_group in _define_cluster_group() depending on the result of the cluster search (DBScan).

Does this make sense? The problem is that before determining cluster_group for the given compound, the cluster search has to be performed for both compounds and the merge of the clusters (largest cluster of this compound + the smaller clusters of the other compound) has to be performed...

Bottom of the line: don't accept my pull request, but actually I didn't want to completely undo my initial modifications, maybe they can be of some help (I did what we agreed on)...

