### PR TITLE
Patched Interface Analyzers

### DIFF
--- a/pytim/chacon_tarazona.py
+++ b/pytim/chacon_tarazona.py
@@ -72,6 +72,10 @@ class ChaconTarazona(pytim.PYTIM):
     >>> print repr(interface.layers)
     array([[<AtomGroup with 175 atoms>],
            [<AtomGroup with 159 atoms>]], dtype=object)
+    >>> interface = pytim.ChaconTarazona(g,alpha=2.,tau=1.5,info=False,molecular=False)
+    >>> print repr(interface.layers)
+    array([[<AtomGroup with 175 atoms>],
+           [<AtomGroup with 159 atoms>]], dtype=object)
 
     """
     _surface = None
@@ -118,7 +122,7 @@ class ChaconTarazona(pytim.PYTIM):
         self.surf = None
         self.modes = [None, None]
 
-        pytim.PatchTrajectory(universe.trajectory, self)
+        pytim.PatchTrajectory(self.universe.trajectory, self)
         self._assign_layers()
         self._atoms = self.LayerAtomGroupFactory(
             self._layers[:].sum().indices, self.universe)

--- a/pytim/gitim.py
+++ b/pytim/gitim.py
@@ -90,7 +90,7 @@ class GITIM(pytim.PYTIM):
         if(self.symmetry == 'planar'):
             sanity.assign_normal(normal)
 
-        pytim.PatchTrajectory(universe.trajectory, self)
+        pytim.PatchTrajectory(self.universe.trajectory, self)
 
         self._assign_layers()
 
@@ -116,7 +116,7 @@ class GITIM(pytim.PYTIM):
 
         points = self.triangulation.points
         radii = self.triangulation.radii
-    
+
         R = []
         r_i = points[simplex]
         rad_i = radii[simplex]
@@ -175,8 +175,8 @@ class GITIM(pytim.PYTIM):
             extrapoints = np.copy(points)
             extraids = np.arange(len(points), dtype=np.int)
         # add points at the vertices of the expanded (by 2 alpha) box
-        cube_vertices = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 1.0, 0.0], 
-                                  [0.0, 1.0, 1.0], [1.0, 0.0, 0.0], [1.0, 0.0, 1.0], 
+        cube_vertices = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 1.0, 0.0],
+                                  [0.0, 1.0, 1.0], [1.0, 0.0, 0.0], [1.0, 0.0, 1.0],
                                   [1.0, 1.0, 0.0], [1.0, 1.0, 1.0]])
         if self._noextrapoints == False:
             for dim,vertex in enumerate(cube_vertices):

--- a/pytim/itim.py
+++ b/pytim/itim.py
@@ -203,7 +203,7 @@ class ITIM(pytim.PYTIM):
         self.use_kdtree = True
         self.use_multiproc = multiproc
 
-        pytim.PatchTrajectory(universe.trajectory, self)
+        pytim.PatchTrajectory(self.universe.trajectory, self)
 
         self._assign_layers()
         self._atoms = self.LayerAtomGroupFactory(
@@ -232,7 +232,7 @@ class ITIM(pytim.PYTIM):
             _box[:2] = box[:2]
             try: # older scipy versions
                 self.meshtree = cKDTree(self.meshpoints, boxsize=_box)
-            except: 
+            except:
                 self.meshtree = cKDTree(self.meshpoints, boxsize=_box[:2])
 
     def _touched_lines(self, atom, _x, _y, _z, _radius):

--- a/pytim/willard_chandler.py
+++ b/pytim/willard_chandler.py
@@ -49,6 +49,13 @@ class WillardChandler(pytim.PYTIM):
     >>> print "Radius={:.3f}".format(R)
     Radius=19.383
 
+    >>> # the fast kernel gives a slightly (<0.1 Angstrom) different result
+    >>> interface = pytim.WillardChandler(g, alpha=3.0, fast=True)
+    >>> R, _, _, _ = pytim.utilities.fit_sphere(\
+                       interface.triangulated_surface[0])
+    >>> print "Radius={:.3f}".format(R)
+    Radius=19.383
+
     """
 
     _surface = None
@@ -97,7 +104,7 @@ class WillardChandler(pytim.PYTIM):
 
         self.fast = fast
 
-        pytim.PatchTrajectory(universe.trajectory, self)
+        pytim.PatchTrajectory(self.universe.trajectory, self)
         self._assign_layers()
         self._atoms = self._layers[:]  # this is an empty AtomGroup
         self.writevtk = WillardChandler.Writevtk(self)


### PR DESCRIPTION
Every surface analyzer now accepts an AtomGroup as first argument.
This AtomGroup overrides the one supplied under the group argument.

Added tests to willard-chandler and chacon-tarazona. The gitim and
itim are NOT used when
pytim setup.py test
is issued. This sould be fixed