### PR TITLE
added new atom properties (layer, side, cluster)

### DIFF
--- a/pytim/chacon_tarazona.py
+++ b/pytim/chacon_tarazona.py
@@ -201,6 +201,8 @@ class ChaconTarazona(pytim.PYTIM):
         layers.
 
         """
+        self.label_group(self.universe.atoms, beta=0.0,
+                         layer=-1, cluster=-1, side=-1)
 
         # TODO parallelize
 
@@ -218,9 +220,9 @@ class ChaconTarazona(pytim.PYTIM):
         # we always (internally) center in Chacon-Tarazona
         self.center(planar_to_origin=True)
         # first we label all atoms in group to be in the gas phase
-        self.label_group(self.itim_group.atoms, 0.5)
+        self.label_group(self.itim_group.atoms, beta=0.5)
         # then all atoms in the largest group are labelled as liquid-like
-        self.label_group(self.cluster_group.atoms, 0)
+        self.label_group(self.cluster_group.atoms, bega=0.0)
 
         self.old_box = box
         pos = self.cluster_group.positions
@@ -229,7 +231,8 @@ class ChaconTarazona(pytim.PYTIM):
             self._layers[side][0] = self._assign_one_side(side)
         for side in [0, 1]:
             for _nlayer, _layer in enumerate(self._layers[side]):
-                self.label_group(_layer, _nlayer + 1)
+                self.label_group(_layer, beta=_nlayer + 1.0,
+                                 layer=_nlayer + 1, side=side)
 
         if self.do_center == False:
             self.universe.atoms.positions = self.original_positions

--- a/pytim/gitim.py
+++ b/pytim/gitim.py
@@ -207,6 +207,7 @@ class GITIM(pytim.PYTIM):
     def _assign_layers(self):
         """Determine the GITIM layers."""
         # this can be used later to shift back to the original shift
+        self.label_group(self.universe.atoms, beta=0.0, layer=-1, cluster=-1, side=-1)
         self.original_positions = np.copy(self.universe.atoms.positions[:])
         self.universe.atoms.pack_into_box()
 
@@ -217,9 +218,9 @@ class GITIM(pytim.PYTIM):
             self.center()
 
         # first we label all atoms in group to be in the gas phase
-        self.label_group(self.itim_group.atoms, 0.5)
+        self.label_group(self.itim_group.atoms, beta=0.5)
         # then all atoms in the larges group are labelled as liquid-like
-        self.label_group(self.cluster_group.atoms, 0.0)
+        self.label_group(self.cluster_group.atoms, beta=0.0)
 
         size = len(self.cluster_group.positions)
 
@@ -232,7 +233,7 @@ class GITIM(pytim.PYTIM):
             self._layers[0] = self.cluster_group[alpha_ids]
 
         for layer in self._layers:
-            self.label_group(layer, 1.0)
+            self.label_group(layer, beta = 1.0, layer = 1 )
 
         # reset the interpolator
         self._interpolator = None

--- a/pytim/willard_chandler.py
+++ b/pytim/willard_chandler.py
@@ -122,7 +122,6 @@ class WillardChandler(pytim.PYTIM):
             color = (np.array(color) / 256.).tolist()
             vtk.write_atomgroup(filename, group, color=color, radius=radii)
 
-
         def density(self, filename='pytim_dens.vtk', sequence=False):
             """ Write to vtk files the volumetric density:
                 :param str filename: the file name
@@ -235,7 +234,6 @@ class WillardChandler(pytim.PYTIM):
         surf = self.triangulated_surface[1]
         wavefront_obj.write_file(filename, vert, surf)
 
-
     def _assign_layers(self):
         """There are no layers in the Willard-Chandler method.
 
@@ -243,6 +241,8 @@ class WillardChandler(pytim.PYTIM):
         triangulated isosurface, the density and the particles.
 
         """
+        self.label_group(self.universe.atoms, beta=0.0,
+                         layer=-1, cluster=-1, side=-1)
         # we assign an empty group for consistency
         self._layers = self.universe.atoms[:0]
 


### PR DESCRIPTION
Replaces buggy `interface.atoms` and `interface.atoms.in_layer` with new properties of the `Atom` class of `MDAnalysis`. 

It is now possible to select atoms according to which layer, side of interface, or cluster they belong to. 

* The new properties are `layers`, `sides`, `clusters`  (and the corresponding singular versions)
* The default values are -1 if the quantity has not been assigned. 
* Layers start counting from 1
* sides are 0 or 1 
* clusters can be 0 (belonging to main cluster), -1 (not assigned), 1 (belonging to smaller clusters)


Example:

    import MDAnalysis as mda
    import pytim 
    from pytim.datafiles import WATER_GRO
    u = mda.Universe(WATER_GRO)
    inter = pytim.ITIM(u,max_layers=2, cluster_cut = 2.3 )

    # select atoms in the first layer 
    select = inter.atoms.layers == 1
    print inter.atoms[select]
   
    # print the layer & side to which the first atom in the interface belongs to
    print inter.atoms[0].layer, inter.atoms[0].side
    
    # select all atoms not in the main cluster
    select = u.atoms.clusters == 1 
    print u.atoms[select]


