### PR TITLE
added new atom properties (layer, side, cluster)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,67 @@ as well as common structure file formats such as XYZ or PDB (have a look at the 
 
 Ok, ok ... have a look below: the pytim part of the notebook is actually all enclosed in cells [1] and [2]. Cells from [3] to [6] are for visualization. This example is about computing molecular layers of a flat interface:
 
-<img src="https://github.com/Marcello-Sega/pytim/raw/IMAGES/_images/notebook2.png" width="auto" align="center" style="z-index:999;">
+### Step 1: interface identification
+
+
+```python
+import MDAnalysis as mda
+import pytim
+from pytim.datafiles import WATER_GRO
+
+# load the configuration in MDAnalysis
+u = mda.Universe(WATER_GRO)
+
+# compute the interface using ITIM. Identify 4 layers.
+inter = pytim.ITIM(u,max_layers=4,centered=True)
+```
+
+### That's it. There's no step 2!
+
+Now interfacial atoms are accessible in different ways, pick the one you like:
+
+
+```python
+inter.atoms.positions # this is a numpy array holding the position of atoms in the layers
+```
+
+    array([[ 22.10000038,  16.05999947,  94.19633484],
+           [ 22.43999863,  16.97999954,  93.96632385],
+           ...,
+           [ 33.70999908,  49.02999878,  62.52632904],
+           [ 34.06999969,  48.18000031,  61.16632843]], dtype=float32)
+
+Each atom has now a label that specifies in which layer it is found: 
+
+```python
+u.atoms.layers 
+```
+    
+### Use `nglview` to visualize the system
+
+
+```python
+import nglview
+v = nglview.show_mdanalysis(u)
+v.camera='orthographic'
+v.center()
+system = v.component_0
+colors = ['','red','orange','yellow','white']
+```
+
+```python
+for n in [1,2,3,4]:
+    system.add_spacefill(selection = inter.atoms[inter.atoms.layers==n].indices, color=colors[n] )
+
+system.add_spacefill(selection = (u.atoms - inter.atoms).indices, color='gray' )
+```
+
+```python
+v
+```
+
+<img src="https://github.com/Marcello-Sega/pytim/raw/IMAGES/_images/output_13_0.png" width="100%" align="right" style="z-index:999;">
+
 
 ## <a name="non-flat-interfaces"></a> What if the interface is not flat? 
 

--- a/pytim/chacon_tarazona.py
+++ b/pytim/chacon_tarazona.py
@@ -120,8 +120,6 @@ class ChaconTarazona(pytim.PYTIM):
 
         pytim.PatchTrajectory(self.universe.trajectory, self)
         self._assign_layers()
-        self._atoms = self.LayerAtomGroupFactory(
-            self._layers[:].sum().indices, self.universe)
 
     def _points_next_to_surface(self, surf, modes, pivot):
         """ searches for points within a distance self.tau from the
@@ -201,6 +199,8 @@ class ChaconTarazona(pytim.PYTIM):
         layers.
 
         """
+        self.label_group(self.universe.atoms, beta=0.0,
+                         layer=-1, cluster=-1, side=-1)
 
         # TODO parallelize
 
@@ -218,9 +218,9 @@ class ChaconTarazona(pytim.PYTIM):
         # we always (internally) center in Chacon-Tarazona
         self.center(planar_to_origin=True)
         # first we label all atoms in group to be in the gas phase
-        self.label_group(self.itim_group.atoms, 0.5)
+        self.label_group(self.itim_group.atoms, beta=0.5)
         # then all atoms in the largest group are labelled as liquid-like
-        self.label_group(self.cluster_group.atoms, 0)
+        self.label_group(self.cluster_group.atoms, beta=0.0)
 
         self.old_box = box
         pos = self.cluster_group.positions
@@ -229,7 +229,8 @@ class ChaconTarazona(pytim.PYTIM):
             self._layers[side][0] = self._assign_one_side(side)
         for side in [0, 1]:
             for _nlayer, _layer in enumerate(self._layers[side]):
-                self.label_group(_layer, _nlayer + 1)
+                self.label_group(_layer, beta=_nlayer + 1.0,
+                                 layer=_nlayer + 1, side=side)
 
         if self.do_center == False:
             self.universe.atoms.positions = self.original_positions

--- a/pytim/gitim.py
+++ b/pytim/gitim.py
@@ -94,9 +94,6 @@ class GITIM(pytim.PYTIM):
 
         self._assign_layers()
 
-        self._atoms = self.LayerAtomGroupFactory(
-            self._layers[:].sum().indices, self.universe)
-
     def _sanity_checks(self):
         """ Basic checks to be performed after the initialization.
 
@@ -207,6 +204,7 @@ class GITIM(pytim.PYTIM):
     def _assign_layers(self):
         """Determine the GITIM layers."""
         # this can be used later to shift back to the original shift
+        self.label_group(self.universe.atoms, beta=0.0, layer=-1, cluster=-1, side=-1)
         self.original_positions = np.copy(self.universe.atoms.positions[:])
         self.universe.atoms.pack_into_box()
 
@@ -217,9 +215,9 @@ class GITIM(pytim.PYTIM):
             self.center()
 
         # first we label all atoms in group to be in the gas phase
-        self.label_group(self.itim_group.atoms, 0.5)
+        self.label_group(self.itim_group.atoms, beta=0.5)
         # then all atoms in the larges group are labelled as liquid-like
-        self.label_group(self.cluster_group.atoms, 0.0)
+        self.label_group(self.cluster_group.atoms, beta=0.0)
 
         size = len(self.cluster_group.positions)
 
@@ -232,7 +230,7 @@ class GITIM(pytim.PYTIM):
             self._layers[0] = self.cluster_group[alpha_ids]
 
         for layer in self._layers:
-            self.label_group(layer, 1.0)
+            self.label_group(layer, beta = 1.0, layer = 1 )
 
         # reset the interpolator
         self._interpolator = None

--- a/pytim/itim.py
+++ b/pytim/itim.py
@@ -105,28 +105,22 @@ class ITIM(pytim.PYTIM):
         >>> interface.atoms
         <AtomGroup with 5604 atoms>
 
-        >>> # or a selection of them, using slicing:
-        >>> interface.atoms.in_layers[1,0:4:2]
-        <AtomGroup with 1440 atoms>
-
-        >>> interface.atoms.in_layers[0] # all layers in the upper side
+        >>> selection = interface.atoms.sides == 0
+        >>> interface.atoms[ selection ] # all atoms in the upper side layer
         <AtomGroup with 2823 atoms>
-        >>> interface.atoms.in_layers[0,1] # upper side, second layer
+        >>> selection = np.logical_and(interface.atoms.layers == 2 , selection)
+        >>> interface.atoms[ selection ] # upper side, second layer
         <AtomGroup with 690 atoms>
 
         >>> # the whole system can be quickly saved to a pdb file
         >>> # including the layer information, written in the beta field
         >>> # using:
         >>> interface.writepdb('system.pdb',centered=True)
-        >>> interface.writepdb('first-layers.pdb',centered=True,group=interface.atoms.in_layers[:,0])
-        >>> interface.writepdb('upper-side.pdb',centered=True,group=interface.atoms.in_layers[0:])
 
         >>> # of course, the native interface of MDAnalysis can be used to write pdb files
         >>> # but the centering options are not available. Writing to other formats that
         >>> # do not support the beta factor will loose the information on the layers.
         >>> interface.atoms.write('only_layers.pdb')
-        >>> interface.atoms.in_layers[0].write('only_uppeer_side.pdb')
-        >>> interface.atoms.in_layers[:,1].write('only_second_layers.pdb')
 
     """
 
@@ -206,8 +200,6 @@ class ITIM(pytim.PYTIM):
         pytim.PatchTrajectory(self.universe.trajectory, self)
 
         self._assign_layers()
-        self._atoms = self.LayerAtomGroupFactory(
-            self._layers[:].sum().indices, self.universe)
 
     def _assign_mesh(self):
         """determine a mesh size for the testlines that is compatible with the
@@ -222,15 +214,17 @@ class ITIM(pytim.PYTIM):
         if(self.use_kdtree == True):
             # fixing a bug in mgrid(): e.g. np.mgrid[0:46.7227401733:0.399339659][-1] is larger than the limit
             # tested on numpy 1.13.3
-            delta=np.array([0.,0.])
-            maxd = [ np.max(np.mgrid[0:box[0]:self.mesh_dx]), np.max(np.mgrid[0:box[1]:self.mesh_dy]) ]
-            delta[maxd>=box[:2]]=1e-6
-            _x, _y = np.mgrid[0:box[0]-delta[0]:self.mesh_dx, 0:box[1]-delta[1]:self.mesh_dy]
+            delta = np.array([0., 0.])
+            maxd = [np.max(np.mgrid[0:box[0]:self.mesh_dx]),
+                    np.max(np.mgrid[0:box[1]:self.mesh_dy])]
+            delta[maxd >= box[:2]] = 1e-6
+            _x, _y = np.mgrid[0:box[0] - delta[0]
+                :self.mesh_dx, 0:box[1] - delta[1]:self.mesh_dy]
             self.meshpoints = builtin_zip(_x.ravel(), _y.ravel())
             # cKDTree requires a box vetor with length double the dimension,
             _box = np.zeros(4)
             _box[:2] = box[:2]
-            try: # older scipy versions
+            try:  # older scipy versions
                 self.meshtree = cKDTree(self.meshpoints, boxsize=_box)
             except:
                 self.meshtree = cKDTree(self.meshpoints, boxsize=_box[:2])
@@ -344,6 +338,8 @@ class ITIM(pytim.PYTIM):
 
         """
 
+        self.label_group(self.universe.atoms, beta=0.0,
+                         layer=-1, cluster=-1, side=-1)
         self._assign_mesh()
         up = 0
         low = 1
@@ -363,9 +359,9 @@ class ITIM(pytim.PYTIM):
         self.center(planar_to_origin=True)
 
         # first we label all atoms in group to be in the gas phase
-        self.label_group(self.itim_group.atoms, 0.5)
+        self.label_group(self.itim_group.atoms, beta=0.5)
         # then all atoms in the largest group are labelled as liquid-like
-        self.label_group(self.cluster_group.atoms, 0.0)
+        self.label_group(self.cluster_group.atoms, beta=0.0)
 
         _radius = self.cluster_group.radii
         self._seen = [[], []]
@@ -412,11 +408,12 @@ class ITIM(pytim.PYTIM):
                     low, sort[::], _x, _y, _z, _radius)):
                 self._layers[low][index] = group
 
-        # assign labels to all layers. This can be the bfactor or the
-        # tempfactor property, depending on the MDA version
+        # Assign to all layers a label (tempfactor) that can be used in pdb files.
+        # Additionally, set the new layers and sides
         for uplow in [up, low]:
             for nlayer, layer in enumerate(self._layers[uplow]):
-                self.label_group(layer, nlayer + 1.0)
+                self.label_group(layer, beta=nlayer + 1.0,
+                                 layer=nlayer + 1, side=uplow)
 
         for nlayer, layer in enumerate(self._layers[0]):
             self._surfaces[nlayer] = Surface(self, options={'layer': nlayer})

--- a/pytim/observables.py
+++ b/pytim/observables.py
@@ -687,11 +687,11 @@ class Profile(object):
     >>> inter = pytim.ITIM(u,group=g,max_layers=4,centered=True)
     >>>
     >>> Layers=[]
-    >>> AIL = inter.atoms.in_layers
     >>>
     >>> Layers.append(Profile(u.atoms))
-    >>> for n in np.arange(4):
-    ...     Layers.append(Profile(AIL[::,n]))
+    >>> for n in np.arange(1,5):
+    ...     condition = inter.atoms.layers == n
+    ...     Layers.append(Profile(inter.atoms[condition]))
     >>>
     >>> for ts in u.trajectory[::50]:
     ...     for L in Layers:
@@ -720,11 +720,11 @@ class Profile(object):
         inter = pytim.ITIM(u,group=g,max_layers=4,centered=True)
 
         Layers=[]
-        AIL = inter.atoms.in_layers
 
         Layers.append(Profile(u.atoms))
-        for n in np.arange(4):
-            Layers.append(Profile(AIL[::,n]))
+        for n in np.arange(1,5):
+            condition = inter.atoms.layers == n
+            Layers.append(Profile(inter.atoms[condition]))
 
         for ts in u.trajectory[::]:
             for L in Layers:

--- a/pytim/tests/test_observables.py
+++ b/pytim/tests/test_observables.py
@@ -60,11 +60,11 @@ class TestObservables():
     >>> inter = pytim.ITIM(u,group=g,max_layers=4,centered=True)
     >>> 
     >>> Layers=[]
-    >>> AIL = inter.atoms.in_layers
     >>> 
     >>> Layers.append(Profile(u.atoms))
-    >>> for n in np.arange(4):
-    ...     Layers.append(Profile(AIL[::,n]))
+    >>> for n in np.arange(1,5):
+    ...     condition = inter.atoms.layers == n
+    ...     Layers.append(Profile(inter.atoms[condition]))
     >>> Val=[]
     >>> for ts in u.trajectory[:4]:
     ...     for L in Layers:

--- a/pytim/willard_chandler.py
+++ b/pytim/willard_chandler.py
@@ -122,7 +122,6 @@ class WillardChandler(pytim.PYTIM):
             color = (np.array(color) / 256.).tolist()
             vtk.write_atomgroup(filename, group, color=color, radius=radii)
 
-
         def density(self, filename='pytim_dens.vtk', sequence=False):
             """ Write to vtk files the volumetric density:
                 :param str filename: the file name
@@ -235,7 +234,6 @@ class WillardChandler(pytim.PYTIM):
         surf = self.triangulated_surface[1]
         wavefront_obj.write_file(filename, vert, surf)
 
-
     def _assign_layers(self):
         """There are no layers in the Willard-Chandler method.
 
@@ -243,6 +241,8 @@ class WillardChandler(pytim.PYTIM):
         triangulated isosurface, the density and the particles.
 
         """
+        self.label_group(self.universe.atoms, beta=0.0,
+                         layer=-1, cluster=-1, side=-1)
         # we assign an empty group for consistency
         self._layers = self.universe.atoms[:0]
 


### PR DESCRIPTION
Replaces buggy `interface.atoms` and `interface.atoms.in_layer` with new properties of the `Atom` class of `MDAnalysis`. 

It is now possible to select atoms according to which layer, side of interface, or cluster they belong to. 

* The new properties are `layers`, `sides`, `clusters`  (and the corresponding singular versions)
* The default values are -1 if the quantity has not been assigned. 
* Layers start counting from 1
* sides are 0 or 1 
* clusters can be 0 (belonging to main cluster), -1 (not assigned), 1 (belonging to smaller clusters)


Example:

    import MDAnalysis as mda
    import pytim 
    from pytim.datafiles import WATER_GRO
    u = mda.Universe(WATER_GRO)
    inter = pytim.ITIM(u,max_layers=2, cluster_cut = 2.3 )

    # select atoms in the first layer 
    select = inter.atoms.layers == 1
    print inter.atoms[select]
   
    # print the layer & side to which the first atom in the interface belongs to
    print inter.atoms[0].layer, inter.atoms[0].side
    
    # select all atoms not in the main cluster
    select = u.atoms.clusters == 1 
    print u.atoms[select]


