### PR TITLE
Mdtraj interoperability

### DIFF
--- a/pytim/itim.py
+++ b/pytim/itim.py
@@ -181,7 +181,7 @@ class ITIM(pytim.PYTIM):
 
         self.cluster_threshold_density = cluster_threshold_density
         self.max_layers = max_layers
-        self._layers = np.empty([2, max_layers], dtype=type(universe.atoms))
+        self._layers = np.empty([2, max_layers], dtype=self.universe.atoms[0].__class__)
         self._surfaces = np.empty(max_layers, dtype=type(Surface))
         self.info = info
         self.normal = None

--- a/pytim/tests/test_basics.py
+++ b/pytim/tests/test_basics.py
@@ -63,7 +63,7 @@ class TestBasics():
     >>> # PDB FILE FORMAT
     >>> import MDAnalysis as mda
     >>> import pytim
-    >>> from pytim.datafiles import *
+    >>> from pytim.datafiles import WATER_GRO
     >>> u         = mda.Universe(WATER_GRO)
     >>> oxygens   = u.select_atoms("name OW")
     >>> interface = pytim.ITIM(u, alpha=2.0, max_layers=4,molecular=True)
@@ -73,6 +73,37 @@ class TestBasics():
     >>> beta = line[62:66] # PDB file format is fixed
     >>> print beta
     4.00
+
+
+    >>> # mdtraj 
+    >>> try:
+    ...     import mdtraj
+    ...     try:
+    ...         import numpy as np 
+    ...         import MDAnalysis as mda
+    ...         import pytim
+    ...         from pytim.datafiles import WATER_GRO,WATER_XTC
+    ...         u = mda.Universe(WATER_GRO,WATER_XTC)
+    ...         t = mdtraj.load_xtc(WATER_XTC,top=WATER_GRO)
+    ...         inter = pytim.ITIM(t)
+    ...         ref = pytim.ITIM(u)
+    ...         ids_mda = []
+    ...         ids_mdtraj = []
+    ...         for ts in u.trajectory[0:2]:
+    ...             ids_mda.append(ref.atoms.ids)
+    ...         for ts in t[0:2]:
+    ...             ids_mdtraj.append(inter.atoms.ids)
+    ...         for fr in [0,1]:   
+    ...             if not np.all(ids_mda[fr] == ids_mdtraj[fr]):
+    ...                 print "MDAnalysis and mdtraj surface atoms do not coincide"
+    ...         _a = u.trajectory[1] # we make sure we load the second frame
+    ...         _b = t[1]
+    ...         if not np.all(np.isclose(inter.atoms.positions[0], ref.atoms.positions[0])):
+    ...             print "MDAnalysis and mdtraj atomic positions do not coincide"
+    ...     except:
+    ...         raise RuntimeError("mdtraj available, but a general exception happened")
+    ... except:
+    ...     pass
 
 
     """


### PR DESCRIPTION
This patch makes it possible to use trajectories loaded within `mdtraj` with `pytim`.
`MDAnalysis` is still required as a package to run `pytim`, but this is (almost) transparent for the user.

A basic example:

```python
   import mdtraj                                    
   import pytim                  
   from pytim.datafiles import WATER_GRO, WATER_XTC 

   t = mdtraj.load_xtc(WATER_XTC,top=WATER_GRO) 
   inter = pytim.ITIM(t) 
   for step in t[0:2]:
       print "surface atoms:" , repr(inter.atoms.indices)

```