### PR TITLE
Patch multilayer

### DIFF
--- a/pytim/__init__.py
+++ b/pytim/__init__.py
@@ -449,6 +449,14 @@ class SanityCheck(object):
 
         return True
 
+    def check_multiple_layers_options(self):
+        try:
+            if self.interface.biggest_cluster_only == True and self.interface.cluster_cut == None:
+                self.interface.biggest_cluster_only = False
+                print "Warning: the option biggest_cluster_only has no effect without setting cluster_cut, ignoring it"
+        except:
+            pass
+
 
 class PYTIM(object):
     """ The PYTIM metaclass

--- a/pytim/gitim.py
+++ b/pytim/gitim.py
@@ -109,6 +109,7 @@ class GITIM(pytim.PYTIM):
         self.PDB = {}
         self.molecular = molecular
         sanity.assign_groups(group, cluster_cut, extra_cluster_groups)
+        sanity.check_multiple_layers_options()
         sanity.assign_radii()
 
         self._assign_symmetry(symmetry)

--- a/pytim/tests/test_basics.py
+++ b/pytim/tests/test_basics.py
@@ -106,6 +106,19 @@ class TestBasics():
     ...     pass
 
 
+    >>> # check that using the biggest_cluster_only option without setting cluster_cut
+    >>> # throws a warning and resets to biggest_cluster_only == False
+    >>> import MDAnalysis as mda
+    >>> import pytim
+    >>> from   pytim.datafiles import GLUCOSE_PDB
+    >>>
+    >>> u       = mda.Universe(GLUCOSE_PDB)
+    >>> solvent = u.select_atoms('name OW')
+    >>> inter = pytim.GITIM(u, group=solvent, biggest_cluster_only=True)
+    Warning: the option biggest_cluster_only has no effect without setting cluster_cut, ignoring it
+
+    >>> print inter.biggest_cluster_only
+    False
     """
 
     pass


### PR DESCRIPTION
bug: passing `biggest_cluster_only=True` and no `cluster_cut` to `pytim.GITIM` crashed the code
fix: adding a check in the sanity tests

test added to pytim/tests/test_basics.py
