### PR TITLE
Fixed grid for ITIM

### DIFF
--- a/pytim/itim.py
+++ b/pytim/itim.py
@@ -8,6 +8,7 @@
 
 from multiprocessing import Process, Queue
 import numpy as np
+from __builtin__ import zip as builtin_zip
 from scipy.spatial import cKDTree
 from pytim import utilities, surface
 import pytim
@@ -218,7 +219,7 @@ dtype=object)
             _x = np.linspace(0,box[0],num=self.mesh_nx, endpoint=False)
             _y = np.linspace(0,box[1],num=self.mesh_ny, endpoint=False)
             _X,_Y = np.meshgrid(_x,_y)
-            self.meshpoints = zip(_X.ravel(), _Y.ravel())
+            self.meshpoints = builtin_zip(_X.ravel(), _Y.ravel())
             # cKDTree requires a box vetor with length double the dimension,
             _box = np.zeros(4)
             _box[:2] = box[:2]


### PR DESCRIPTION
Using example_water.py with the following line produced an error:
```python
interface = pytim.ITIM(u, alpha=2., max_layers=4, molecular=True,mesh=0.3)
```
Traceback (most recent call last):
  File "example_water.py", line 11, in <module>
    interface = pytim.ITIM(u, alpha=2., max_layers=4, molecular=True,multiproc=False,mesh=0.3)
  File "build/bdist.macosx-10.10-x86_64/egg/pytim/itim.py", line 202, in __init__
  File "build/bdist.macosx-10.10-x86_64/egg/pytim/itim.py", line 405, in _assign_layers
  File "build/bdist.macosx-10.10-x86_64/egg/pytim/itim.py", line 250, in _assign_one_side
IndexError: index 28031 is out of bounds for axis 1 with size 27889

This came from the _assign_mesh() method.
A fix has been implemented along with a slightly extended documentation.

In addition:
- the unused self.delta attribute was removed

