### PR TITLE
Documentation

### DIFF
--- a/pytim/__init__.py
+++ b/pytim/__init__.py
@@ -31,13 +31,13 @@ class PYTIM(object):
     layers, _layers =\
         _create_property('layers', "AtomGroups of atoms in layers")
     itim_group, _itim_group =\
-        _create_property('itim_group', "(AtomGroup) the group,"
+        _create_property('itim_group', "(AtomGroup) the group, "
                          "the surface of which should be computed")
     cluster_cut, _cluster_cut =\
-        _create_property('cluster_cut', "(real) cutoff for phase"
+        _create_property('cluster_cut', "(real) cutoff for phase "
                          "identification")
     molecular, _molecular =\
-        _create_property('molecular', "(bool) wheter to compute"
+        _create_property('molecular', "(bool) whether to compute "
                          "surface atoms or surface molecules")
     surfaces, _surfaces =\
         _create_property('surfaces', "Surfaces associated to the interface",
@@ -91,7 +91,7 @@ class PYTIM(object):
     def label_group(self, group, beta=None, layer=None, cluster=None, side=None):
         if group is None:
             raise RuntimeError(
-                'one of the groups, possibly a layer one, is None.' + 
+                'one of the groups, possibly a layer one, is None.' +
                 ' Something is wrong...')
         if self.molecular is True:
             _group = group.residues.atoms

--- a/pytim/observables.py
+++ b/pytim/observables.py
@@ -94,14 +94,15 @@ class LayerTriangulation(Observable):
         in the box.
 
         :param Universe universe: the MDAnalysis universe
-        :param ITIM interface   : compute the triangulation with respect to it
-        :param int  layer       : (default: 1) compute the triangulation with
+        :param ITIM interface:    compute the triangulation with respect to it
+        :param int  layer:        (default: 1) compute the triangulation with
                                   respect to this layer of the interface
         :param bool return_triangulation: (default: True) return the Delaunay
                                   triangulation used for the interpolation
         :param bool return_statistics: (default: True) return the Delaunay
                                   triangulation used for the interpolation
-        :returns Observable LayerTriangulation:
+
+        :return:                  Observable LayerTriangulation
 
         Example:
 
@@ -172,7 +173,7 @@ class IntrinsicDistance(Observable):
     :param Universe universe: the MDAnalysis universe
     :param ITIM    interface: compute the intrinsic distance with respect
                               to this interface
-    :param int     layer    : (default: 1) compute the intrinsic distance
+    :param int     layer:     (default: 1) compute the intrinsic distance
                               with respect to this layer of the interface
 
     Example: TODO
@@ -190,13 +191,13 @@ class IntrinsicDistance(Observable):
 
         :param ndarray positions: compute the intrinsic distance for this set
                                   of points
-
         """
         return self.interface._surfaces[0].distance(inp)
 
 
 class Number(Observable):
-    """The number of atoms."""
+    """The number of atoms.
+    """
 
     def __init__(self, *arg, **kwarg):
         Observable.__init__(self, None)

--- a/pytim/pdb.py
+++ b/pytim/pdb.py
@@ -8,7 +8,7 @@ import MDAnalysis
 
 def _writepdb(interface, filename='layers.pdb', centered='no', group='all', multiframe=True):
     """ Write the frame to a pdb file, marking the atoms belonging
-        to the layers with different beta factor.
+        to the layers with different beta factors.
 
         :param str       filename   : the output file name
         :param str       centered   : 'origin', 'middle', or 'no'

--- a/pytim/rdf.py
+++ b/pytim/rdf.py
@@ -22,11 +22,11 @@ class RDF(object):
             f_1(r_i,v_i)\cdot f_2(r_j,v_j) \\right\\rangle
 
 
-    :param double max_radius:  compute the rdf up to this distance. If 'full'
-                               is supplied (default) computes it up to half of
-                               the smallest box side.
-    :param int nbins        :  number of bins
-    :param Observable observable :  observable for the first group
+    :param double max_radius:       compute the rdf up to this distance. If 'full'
+                                    is supplied (default) computes it up to half of
+                                    the smallest box side.
+    :param int nbins:               number of bins
+    :param Observable observable:   observable for the first group
     :param Observable observable2:  observable for the second group
 
     Example:
@@ -205,10 +205,10 @@ class RDF2D(RDF):
     having the same size of the group. The scalar product between the
     two functions is used to weight the distriution function.
 
-    :param int nbins        : number of bins
-    :param char excluded_dir: project position vectors onto the plane
-                              orthogonal to 'z','y' or 'z'
-    :param Observable observable :  observable for group 1
+    :param int nbins:               number of bins
+    :param char excluded_dir:       project position vectors onto the plane
+                                    orthogonal to 'z','y' or 'z'
+    :param Observable observable:   observable for group 1
     :param Observable observable2:  observable for group 2
 
     Example:

--- a/pytim/rdf.py
+++ b/pytim/rdf.py
@@ -22,9 +22,9 @@ class RDF(object):
             f_1(r_i,v_i)\cdot f_2(r_j,v_j) \\right\\rangle
 
 
-    :param double max_radius:       compute the rdf up to this distance. If 'full'
-                                    is supplied (default) computes it up to half of
-                                    the smallest box side.
+    :param double max_radius:       compute the rdf up to this distance.
+                                    If 'full' is supplied (default) computes
+                                    it up to half of the smallest box side.
     :param int nbins:               number of bins
     :param Observable observable:   observable for the first group
     :param Observable observable2:  observable for the second group

--- a/pytim/willard_chandler.py
+++ b/pytim/willard_chandler.py
@@ -77,7 +77,8 @@ class WillardChandler(pytim.PYTIM):
 
     @property
     def layers(self):
-        """The method does not identify layers."""
+        """ The method does not identify layers.
+        """
         self.layers = None
         return None
 
@@ -126,9 +127,9 @@ class WillardChandler(pytim.PYTIM):
         """ Write to cube files (sequences) the volumentric density and the
             atomic positions.
 
-            :param str filename: the file name
+            :param str filename:  the file name
             :param bool sequence: if true writes a sequence of files adding
-            the frame to the filename
+                                  the frame to the filename
 
             >>> import MDAnalysis as mda
             >>> import pytim
@@ -149,9 +150,9 @@ class WillardChandler(pytim.PYTIM):
     def writeobj(self, filename="pytim.obj", sequence=False):
         """ Write to wavefront obj files (sequences) the triangulated surface
 
-            :param str filename: the file name
+            :param str filename:  the file name
             :param bool sequence: if true writes a sequence of files adding
-            the frame to the filename
+                                  the frame to the filename
 
             >>> import MDAnalysis as mda
             >>> import pytim
@@ -172,10 +173,10 @@ class WillardChandler(pytim.PYTIM):
         wavefront_obj.write_file(filename, vert, surf)
 
     def _assign_layers(self):
-        """There are no layers in the Willard-Chandler method.
+        """ There are no layers in the Willard-Chandler method.
 
-        This function identifies the dividing surface and stores the
-        triangulated isosurface, the density and the particles.
+            This function identifies the dividing surface and stores the
+            triangulated isosurface, the density and the particles.
 
         """
         self.label_group(self.universe.atoms, beta=0.0,
@@ -233,8 +234,9 @@ class Writevtk(object):
         self.interface = interface
 
     def _dump_group(self, group, filename):
-        """save the particles n a vtk file named consecutively using the frame
-        number."""
+        """ Save the particles n a vtk file named consecutively using the frame
+            number.
+        """
         radii = group.radii
         types = group.types
         color = [(utilities.atoms_maps[element])['color'] for element in types]
@@ -242,10 +244,11 @@ class Writevtk(object):
         vtk.write_atomgroup(filename, group, color=color, radius=radii)
 
     def density(self, filename='pytim_dens.vtk', sequence=False):
-        """ Write to vtk files the volumetric density:
-            :param str filename: the file name
+        """ Write to vtk files the volumetric density.
+
+            :param str filename:  the file name
             :param bool sequence: if true writes a sequence of files adding
-            the frame to the filename
+                                  the frame to the filename
 
             >>> import MDAnalysis as mda
             >>> import pytim
@@ -265,10 +268,11 @@ class Writevtk(object):
                               inter.spacing, inter.density_field)
 
     def particles(self, filename='pytim_part.vtk', group=None, sequence=False):
-        """ Write to vtk files the particles in a group:
-            :param str filename: the file name
-            :param bool sequence: if true writes a sequence of files adding
-            the frame to the filename
+        """ Write to vtk files the particles in a group.
+
+            :param str filename:    the file name
+            :param bool sequence:   if true writes a sequence of files adding
+                                    the frame to the filename
             :param AtomGroup group: if None, writes the whole universe
 
             >>> import MDAnalysis as mda
@@ -283,6 +287,7 @@ class Writevtk(object):
             >>> # writes on part.<frame>.vtk
             >>> inter.writevtk.particles('part.vtk',sequence=True)
         """
+
         inter = self.interface
         if sequence is True:
             filename = vtk.consecutive_filename(inter.universe, filename)
@@ -291,10 +296,11 @@ class Writevtk(object):
         self._dump_group(group, filename)
 
     def surface(self, filename='pytim_surf.vtk', sequence=False):
-        """ Write to vtk files the triangulated surface:
-            :param str filename: the file name
+        """ Write to vtk files the triangulated surface.
+
+            :param str filename:  the file name
             :param bool sequence: if true writes a sequence of files adding
-            the frame to the filename
+                                  the frame to the filename
 
             >>> import MDAnalysis as mda
             >>> import pytim


### PR DESCRIPTION
Fixed a bunch of formatting issues and typos in the docstrings.

NOTE:
when writing docstrings:
:param int foo:        -- OK
:param int bar     :   -- NOT OK (not recognized as a parameter because of the spaces before the colon)