### PR TITLE
introduced option to avoid automatic interface determination

### DIFF
--- a/pytim/__init__.py
+++ b/pytim/__init__.py
@@ -68,6 +68,9 @@ class PYTIM(object):
     max_layers, _max_layers =\
         _create_property('max_layers',
                          "(int) maximum number of layers to be identified")
+    autoassign , _autoassign=\
+        _create_property('autoassign',
+                         "(bool) assign layers every time a frame changes")
     cluster_threshold_density, _cluster_threshold_density =\
         _create_property('cluster_threshold_density',
                          "(float) threshold for the density-based filtering")

--- a/pytim/chacon_tarazona.py
+++ b/pytim/chacon_tarazona.py
@@ -65,8 +65,10 @@ class ChaconTarazona(pytim.PYTIM):
                  mesh=None,
                  centered=False,
                  warnings=False,
+                 autoassign=True,
                  **kargs):
 
+        self.autoassign = autoassign
         self.symmetry = 'planar'
         self.do_center = centered
 

--- a/pytim/gitim.py
+++ b/pytim/gitim.py
@@ -115,11 +115,15 @@ J. Chem. Phys. 138, 044110, 2013)*
                  centered=False,
                  info=False,
                  warnings=False,
+                 autoassign = True,
                  _noextrapoints=False,
                  **kargs):
 
         # this is just for debugging/testing
         self._noextrapoints = _noextrapoints
+        self.autoassign = autoassign
+
+
         self.do_center = centered
 
         self.biggest_cluster_only = biggest_cluster_only

--- a/pytim/gitim.py
+++ b/pytim/gitim.py
@@ -115,14 +115,13 @@ J. Chem. Phys. 138, 044110, 2013)*
                  centered=False,
                  info=False,
                  warnings=False,
-                 autoassign = True,
+                 autoassign=True,
                  _noextrapoints=False,
                  **kargs):
 
         # this is just for debugging/testing
         self._noextrapoints = _noextrapoints
         self.autoassign = autoassign
-
 
         self.do_center = centered
 

--- a/pytim/itim.py
+++ b/pytim/itim.py
@@ -159,7 +159,10 @@ J. Comp. Chem. 29, 945, 2008)*
                  centered=False,
                  warnings=False,
                  mesh=0.4,
+                 autoassign = True,
                  **kargs):
+
+        self.autoassign = autoassign
 
         self.symmetry = 'planar'
         self.do_center = centered

--- a/pytim/itim.py
+++ b/pytim/itim.py
@@ -159,7 +159,7 @@ J. Comp. Chem. 29, 945, 2008)*
                  centered=False,
                  warnings=False,
                  mesh=0.4,
-                 autoassign = True,
+                 autoassign=True,
                  **kargs):
 
         self.autoassign = autoassign

--- a/pytim/patches.py
+++ b/pytim/patches.py
@@ -20,13 +20,15 @@ def PatchTrajectory(trajectory, interface):
         class PatchedTrajectory(trajectory.__class__):
             def _read_next_timestep(self, ts=None):
                 tmp = self.original_read_next_timestep(ts=ts)
-                self.interface._assign_layers()
+                if self.interface.autoassign is True:
+                    self.interface._assign_layers()
                 return tmp
 
             def _read_frame_with_aux(self, frame):
                 if frame != self.frame:
                     tmp = self.original_read_frame_with_aux(frame)
-                    self.interface._assign_layers()
+                    if self.interface.autoassign is True:
+                        self.interface._assign_layers()
                     return tmp
                 return self.ts
 
@@ -56,7 +58,8 @@ def PatchOpenMM(simulation, interface):
                 pos = self.context.getState(getPositions=True).getPositions(
                     asNumpy=True).value_in_unit(openmm_AA)
                 self.interface.universe.atoms.positions = pos
-                self.interface._assign_layers()
+                if self.interface.autoassign is True:
+                    self.interface._assign_layers()
                 return tmp
 
         oldname = simulation.__class__.__name__
@@ -88,7 +91,8 @@ def PatchMDTRAJ(trajectory, universe):
                     dimensions = slice_.universe.dimensions[:]
                     dimensions[0:3] = slice_.unitcell_lengths[0:3] * 10.0
                     slice_.universe.dimensions = dimensions
-                    slice_.universe.trajectory.interface._assign_layers()
+                    if slice_.universe.trajectory.interface.autoassign is True:
+                        slice_.universe.trajectory.interface._assign_layers()
                 return slice_
 
         oldname = trajectory.__class__.__name__

--- a/pytim/willard_chandler.py
+++ b/pytim/willard_chandler.py
@@ -102,9 +102,11 @@ class WillardChandler(pytim.PYTIM):
                  extra_cluster_groups=None,
                  centered=False,
                  warnings=False,
+                 autoassign=True,
                  fast=True,
                  **kargs):
 
+        self.autoassign = autoassign
         self.do_center = centered
         sanity = SanityCheck(self)
         sanity.assign_universe(


### PR DESCRIPTION
passing the 'autoassign=False' option to the various PYTIM class implementations disables the automatic assignment when switching frame.

Usage example:
```
inter = pytim.GITIM(u,group=u.select_atoms('name OW'), autoassign=False)
```