### PR TITLE
allows zero surface atoms in gitim

### DIFF
--- a/pytim/Interface.py
+++ b/pytim/Interface.py
@@ -115,6 +115,8 @@ class Interface(object):
             raise RuntimeError(
                 'one of the groups, possibly a layer one, is None.' +
                 ' Something is wrong...')
+        if len(group) == 0:
+            return
         if self.molecular is True:
             _group = group.residues.atoms
         else:

--- a/pytim/gitim.py
+++ b/pytim/gitim.py
@@ -327,7 +327,7 @@ J. Chem. Phys. 138, 044110, 2013)*
                 group = group[np.where(np.array(l) == np.argmax(c))[0]]
 
             alpha_group = alpha_group[:] - group[:]
-            if len(group)>0:
+            if len(group) > 0:
                 if self.molecular:
                     self._layers[layer] = group.residues.atoms
                 else:

--- a/pytim/gitim.py
+++ b/pytim/gitim.py
@@ -208,8 +208,9 @@ J. Chem. Phys. 138, 044110, 2013)*
             u = np.dot(invM, d)
             v = r_i[0] - np.dot(invM, s)
         except np.linalg.linalg.LinAlgError as err:
-            if 'Singular matrix' in err.message and self.warnings is True:
-                print("Warning, singular matrix for ", r_i)
+            if 'Singular matrix' in err.message:
+                if self.warnings is True:
+                    print("Warning, singular matrix for ", r_i)
                 # TODO is this correct? The singular matrix most likely comes
                 # out of points alinged in the plane
                 return 0

--- a/pytim/gitim.py
+++ b/pytim/gitim.py
@@ -327,11 +327,13 @@ J. Chem. Phys. 138, 044110, 2013)*
                 group = group[np.where(np.array(l) == np.argmax(c))[0]]
 
             alpha_group = alpha_group[:] - group[:]
-
-            if self.molecular:
-                self._layers[layer] = group.residues.atoms
+            if len(group)>0:
+                if self.molecular:
+                    self._layers[layer] = group.residues.atoms
+                else:
+                    self._layers[layer] = group
             else:
-                self._layers[layer] = group
+                self._layers[layer] = group.universe.atoms[:0]
 
             self.label_group(
                 self._layers[layer], beta=1. * (layer + 1), layer=(layer + 1))

--- a/pytim/gitim.py
+++ b/pytim/gitim.py
@@ -208,7 +208,7 @@ J. Chem. Phys. 138, 044110, 2013)*
             u = np.dot(invM, d)
             v = r_i[0] - np.dot(invM, s)
         except np.linalg.linalg.LinAlgError as err:
-            if 'Singular matrix' in err.message:
+            if 'Singular matrix' in err.message and self.warnings is True:
                 print("Warning, singular matrix for ", r_i)
                 # TODO is this correct? The singular matrix most likely comes
                 # out of points alinged in the plane

--- a/pytim/tests/test_basics.py
+++ b/pytim/tests/test_basics.py
@@ -49,6 +49,13 @@ class TestBasics():
         ...
     ValueError: parameter alpha must be smaller than the smaller box side
 
+    >>> # TEST:3b no surface atoms
+    >>> u         = mda.Universe(GLUCOSE_PDB)
+    >>> g         = u.select_atoms('type C or name OW')
+    >>> interface = pytim.GITIM(u,group=g, alpha=4.0)
+    >>> print(interface.atoms)
+    <AtomGroup []>
+
     >>> # TEST:4 interchangeability of Universe/AtomGroup
     >>> u         = mda.Universe(WATER_GRO)
     >>> oxygens   = u.select_atoms("name OW")


### PR DESCRIPTION
A bulk simulation without voids larger than the probe sphere radius
does not have any surface

* previous behavior: MDAnalysis raised a ValueError
* new behavior: return empty surface groups
