### PR TITLE
fixed rare condition where pack_into_box() fails

### DIFF
--- a/pytim/itim.py
+++ b/pytim/itim.py
@@ -312,9 +312,8 @@ J. Comp. Chem. 29, 945, 2008)*
         p = self.universe.atoms.positions.copy()
         cond = np.logical_and(self.universe.atoms.positions < 0.0,
                               self.universe.atoms.positions > -1e-5)
-        p[cond]*=0.0
+        p[cond] *= 0.0
         self.universe.atoms.positions = p
-
 
     def _prelabel_groups(self):
         self.label_group(

--- a/pytim/itim.py
+++ b/pytim/itim.py
@@ -307,6 +307,14 @@ J. Comp. Chem. 29, 945, 2008)*
         self.original_positions = np.copy(self.universe.atoms.positions[:])
 
         self.universe.atoms.pack_into_box()
+        # in some rare cases, pack_into_box() returns some points which are
+        # at slightly negative position. We set this by hand to zero.
+        p = self.universe.atoms.positions.copy()
+        cond = np.logical_and(self.universe.atoms.positions < 0.0,
+                              self.universe.atoms.positions > -1e-5)
+        p[cond]*=0.0
+        self.universe.atoms.positions = p
+
 
     def _prelabel_groups(self):
         self.label_group(


### PR DESCRIPTION
in some cases `pack_into_box()` returns some negative positions (~ -1e-6). 
these are reset to zero to avoid problems with negative values passed to `cKDTree`