### PR TITLE
Documentation2

### DIFF
--- a/pytim/observables/correlator.py
+++ b/pytim/observables/correlator.py
@@ -174,7 +174,7 @@ class Correlator(object):
             :parameter bool continuous: applies only when a reference group has
                                         been specified: if True (default) the
                                         contribution of a particle at time lag
-                                        :math:`\\tau=t_1-t_0` is considered 
+                                        :math:`\\tau=t_1-t_0` is considered
                                         only if the particle did not leave the
                                         reference group between :math:`t_0` and
                                         :math:`t_1`. If False, the intermittent
@@ -219,8 +219,8 @@ class Correlator(object):
 
             Note that the average of  the characteristic function
             :math:`h(t)` is done over all trajectories, including those
-            that start with h=0. 
-            The correlation :math:`\\langle h(t)h(0) \\rangle` is divided 
+            that start with h=0.
+            The correlation :math:`\\langle h(t)h(0) \\rangle` is divided
             by the average :math:`\\langle h \\rangle` computed over all
             trajectores that extend up to a time lag :math:`t`. The
             `normalize` switch has no effect.

--- a/pytim/observables/correlator.py
+++ b/pytim/observables/correlator.py
@@ -174,8 +174,8 @@ class Correlator(object):
             :parameter bool continuous: applies only when a reference group has
                                         been specified: if True (default) the
                                         contribution of a particle at time lag
-                                        :math:`\\tau=t_1-t_0` is considered only if
-                                        the particle did not leave the
+                                        :math:`\\tau=t_1-t_0` is considered 
+                                        only if the particle did not leave the
                                         reference group between :math:`t_0` and
                                         :math:`t_1`. If False, the intermittent
                                         correlation is calculated, and the
@@ -219,8 +219,9 @@ class Correlator(object):
 
             Note that the average of  the characteristic function
             :math:`h(t)` is done over all trajectories, including those
-            that start with h=0. The correlation :math:`\\langle h(t)h(0) \\rangle`
-            is divided by the average :math:`\\langle h \\rangle` computed over all
+            that start with h=0. 
+            The correlation :math:`\\langle h(t)h(0) \\rangle` is divided 
+            by the average :math:`\\langle h \\rangle` computed over all
             trajectores that extend up to a time lag :math:`t`. The
             `normalize` switch has no effect.
 

--- a/pytim/observables/correlator.py
+++ b/pytim/observables/correlator.py
@@ -174,10 +174,10 @@ class Correlator(object):
             :parameter bool continuous: applies only when a reference group has
                                         been specified: if True (default) the
                                         contribution of a particle at time lag
-                                        $\\tau=t_1-t_0$ is considered only if
+                                        :math:`\\tau=t_1-t_0` is considered only if
                                         the particle did not leave the
-                                        reference group between $t_0$ and
-                                        $t_1$. If False, the intermittent
+                                        reference group between :math:`t_0` and
+                                        :math:`t_1`. If False, the intermittent
                                         correlation is calculated, and the
                                         above restriction is released.
 
@@ -218,10 +218,10 @@ class Correlator(object):
             >>>
 
             Note that the average of  the characteristic function
-            $h(t)$ is done over all trajectories, including those
-            that start with h=0. The correlation $< h(t) h(0) >$
-            is divided by the average $<h>$ computed over all
-            trajectores that extend up to a time lag $t$. The
+            :math:`h(t)` is done over all trajectories, including those
+            that start with h=0. The correlation :math:`\\langle h(t)h(0) \\rangle`
+            is divided by the average :math:`\\langle h \\rangle` computed over all
+            trajectores that extend up to a time lag :math:`t`. The
             `normalize` switch has no effect.
 
             >>> # normalized, continuous
@@ -235,11 +235,11 @@ class Correlator(object):
 
             The autocorrelation functions are calculated by taking
             into account in the average only those trajectory that
-            start with $h=1$ (i.e., which start within the reference
+            start with :math:`h=1` (i.e., which start within the reference
             group). The normalization is done by dividing the
-            correlation at time lag $t$ by its value at time lag 0
+            correlation at time lag :math:`t` by its value at time lag 0
             computed over all trajectories that extend up to time
-            lag $t$ and do not start with $h=0$.
+            lag :math:`t` and do not start with :math:`h=0`.
 
             >>> # not normalizd, intermittent
             >>> corr = vv.correlation(normalized=False,continuous=False)

--- a/pytim/observables/profile.py
+++ b/pytim/observables/profile.py
@@ -86,6 +86,7 @@ class Profile(object):
     checking presence of a cached copy... not found. Fetching remote file... done.
 
     >>> u = mda.Universe(LJ_GRO,XTC)
+    >>> g = u.select_atoms('all')
     >>>
     >>> inter = pytim.ITIM(u,alpha=2.5,cluster_cut=4.5)
     >>> profile = Profile(interface=inter)

--- a/setup.py
+++ b/setup.py
@@ -11,27 +11,17 @@ import sys
 # Always prefer setuptools over distutils
 try:
     from setuptools import find_packages
-except ImportError:
-    sys.stderr.write("Error : setuptools is not installed\n"
-                     "Use pip install setuptools\n")
+    from Cython.Distutils import build_ext
+    import numpy
+except ImportError as mod_error:
+    mod_name = mod_error.message.split()[3]
+    sys.stderr.write("Error : " + mod_name + " is not installed\n"
+                     "Use pip install " + mod_name + "\n")
     exit(100)
 
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 from distutils.extension import Extension
-try:
-    from Cython.Distutils import build_ext
-except ImportError:
-    sys.stderr.write("Error : cython is not installed\n"
-                     "Use pip install cython\n")
-    exit(100)
-
-try:
-    import numpy
-except ImportError:
-    sys.stderr.write("Error : numpy is not installed\n"
-                     "Use pip install numpy\n")
-    exit(100)
 
 
 class NoseTestCommand(TestCommand):


### PR DESCRIPTION
- Fixed math equations in docstrings
- Fixed example in profile-s:
   The example on how to use the intrinsic profile was not correct.
   The problem was unnoticed, because sphinx tests whole docstring blocks,
   and in that context, it seemingly made sense. However, in the non-intrinsic case,
   the atomgroup g was not correctly defined. 
   **The HTML pages should be updated.**
- Removed duplicate code from setup.py