### PR TITLE
Fixed error in flat intrinsic calculation

### DIFF
--- a/pytim/observables/profile.py
+++ b/pytim/observables/profile.py
@@ -201,7 +201,7 @@ class Profile(object):
         if not isinstance(group, AtomGroup):
             raise TypeError("The first argument passed to "
                             "Profile.sample() must be an AtomGroup.")
-        box = group.universe.trajectory.ts.dimensions[:3]
+        box = group.universe.dimensions[:3]
         if self._range is None:
             self._determine_range(box)
             self._determine_bins()
@@ -313,7 +313,7 @@ class Profile(object):
         >>> prof.sample(u.atoms)
         >>> vals = prof.get_values(binwidth=0.5)[2]
         >>> print(vals[len(vals)//2-3:len(vals)//2+3])
-        [0.07313351 0.04282756 0.02791797        inf 0.         0.        ]
+        [0.07344066 0.04300743 0.02803522        inf 0.         0.        ]
 
 
         >>> sv = prof.sampled_values

--- a/pytim/simple_interface.py
+++ b/pytim/simple_interface.py
@@ -69,7 +69,7 @@ class SimpleInterface(Interface):
         >>> lo,up,av2 = profile2.get_values(binwidth=.5)
         >>> np.set_printoptions(8)
         >>> print (av2[64:70])
-        [0.04159977 0.04035566 0.04028829        inf 0.04518664 0.05085284]
+        [0.04282182 0.04154116 0.04147182        inf 0.04651406 0.05234671]
 
         .. _MDAnalysis: http://www.mdanalysis.org/
 

--- a/pytim/surface.py
+++ b/pytim/surface.py
@@ -229,6 +229,7 @@ class Surface(object):
 
         pos = np.copy(positions)
 
+        # putting everything back in the box in XY
         cond = np.where(pos[:, 0:2] > box[0:2])
         pos[cond] -= box[cond[1]]
         cond = np.where(pos[:, 0:2] < 0 * box[0:2])
@@ -272,17 +273,19 @@ class SurfaceFlatInterface(Surface):
             upper_interp = self._interpolator[0](positions[:, self.xy])
             lower_interp = self._interpolator[1](positions[:, self.xy])
 
-        d1 = upper_interp - positions[:, self.z]
-        d1[np.where(d1 > box / 2.)] -= box
-        d1[np.where(d1 < -box / 2.)] += box
+        d1 = positions[:, self.z] - upper_interp
+        # enforce pbc
+        d1[d1 >  box / 2.] -= box
+        d1[d1 < -box / 2.] += box
 
         d2 = lower_interp - positions[:, self.z]
-        d2[np.where(d2 > box / 2.)] -= box
-        d2[np.where(d2 < -box / 2.)] += box
+        # enforce pbc
+        d2[d2 >  box / 2.] -= box
+        d2[d2 < -box / 2.] += box
 
-        cond = np.where(np.abs(d1) <= np.abs(d2))[0]
-        distance = lower_interp - positions[:, self.z]
-        distance[cond] = positions[cond][:, self.z] - upper_interp[cond]
+        cond = np.abs(d1) <= np.abs(d2)
+        distance = d2
+        distance[cond] = d1[cond]
 
         return distance
 


### PR DESCRIPTION
The flat intrinsic distance calculation gave negative values in a system, where all the molecules of interest were on the outside.

The np.where-s are not necessary when indexing. A few of these have been removed.

Also, the doctest-s have been modified according to the changed intrinsic calculation.


