### PR TITLE
flat interface intrinsic distance fix

### DIFF
--- a/pytim/observables/intrinsic_distance.py
+++ b/pytim/observables/intrinsic_distance.py
@@ -21,6 +21,7 @@ class IntrinsicDistance(Observable):
 
     >>> import MDAnalysis as mda
     >>> import pytim
+    >>> import numpy as np
     >>> from pytim import observables
     >>> from pytim.datafiles import MICELLE_PDB
     >>> u = mda.Universe(MICELLE_PDB)
@@ -29,9 +30,11 @@ class IntrinsicDistance(Observable):
     >>> inter = pytim.GITIM(u,group=micelle, molecular=False, alpha=2.0)
     >>> dist  = observables.IntrinsicDistance(interface=inter)
     >>> d = dist.compute(waterox)
+    >>> np.set_printoptions(precision=3,threshold=10)
     >>> print(d)
     [25.733  8.579  8.852 ... 18.566 13.709  9.876]
 
+    >>> np.set_printoptions(precision=None,threshold=None)
     """
 
     def __init__(self, interface, symmetry='default', mode='default'):

--- a/pytim/observables/profile.py
+++ b/pytim/observables/profile.py
@@ -313,7 +313,8 @@ class Profile(object):
         >>> prof.sample(u.atoms)
         >>> vals = prof.get_values(binwidth=0.5)[2]
         >>> print(vals[len(vals)//2-3:len(vals)//2+3])
-        [0.07313351 0.04282756 0.02791797        inf 0.         0.        ]
+        [0.07344066 0.04300743 0.02803522        inf 0.         0.        ]
+
 
 
         >>> sv = prof.sampled_values

--- a/pytim/simple_interface.py
+++ b/pytim/simple_interface.py
@@ -69,7 +69,8 @@ class SimpleInterface(Interface):
         >>> lo,up,av2 = profile2.get_values(binwidth=.5)
         >>> np.set_printoptions(8)
         >>> print (av2[64:70])
-        [0.04159977 0.04035566 0.04028829        inf 0.04518664 0.05085284]
+        [0.04282182 0.04154116 0.04147182        inf 0.04651406 0.05234671]
+
 
         .. _MDAnalysis: http://www.mdanalysis.org/
 
@@ -127,6 +128,29 @@ class SimpleInterface(Interface):
             self._surfaces = np.empty(1, dtype=type(SurfaceGenericInterface))
             self._surfaces[0] = SurfaceGenericInterface(
                 self, options={'layer': 0})
+
+    def _(self):
+        """ additional tests
+        >>> import pytim
+        >>> import numpy as np
+        >>> from pytim.datafiles import WATER_GRO
+        >>> import MDAnalysis as mda
+        >>> u = mda.Universe(WATER_GRO)
+        >>>
+        >>> u.atoms[:8].positions=np.array([[0.,0,5],[0,1,5],[1,0,5],[1,1,5],
+                [0.,0.,-5.],[0,1,-5],[1,0,-5],[1,1,-5]])
+        >>> upper,lower=u.atoms[:4],u.atoms[4:8]
+        >>> inter = pytim.SimpleInterface(u,symmetry='planar', upper=upper,
+                lower=lower,alpha=5.)
+        >>> g = u.atoms[8:12]
+        >>> g.atoms.positions=np.asarray([[.5,.5,6],[.5,.5,4],[.5,.5,-4],
+                [.5,.5,-6]])
+        >>> print(pytim.observables.IntrinsicDistance(inter).compute(g))
+        [ 1. -1. -1.  1.]
+
+
+
+        """
 
     def _assign_layers(self):
         pass

--- a/pytim/simple_interface.py
+++ b/pytim/simple_interface.py
@@ -137,13 +137,13 @@ class SimpleInterface(Interface):
         >>> import MDAnalysis as mda
         >>> u = mda.Universe(WATER_GRO)
         >>>
-        >>> u.atoms[:8].positions=np.array([[0.,0,5],[0,1,5],[1,0,5],[1,1,5],
+        >>> u.atoms[:8].positions=np.array([[0.,0,5],[0,1,5],[1,0,5],[1,1,5],\
                 [0.,0.,-5.],[0,1,-5],[1,0,-5],[1,1,-5]])
         >>> upper,lower=u.atoms[:4],u.atoms[4:8]
-        >>> inter = pytim.SimpleInterface(u,symmetry='planar', upper=upper,
+        >>> inter = pytim.SimpleInterface(u,symmetry='planar', upper=upper,\
                 lower=lower,alpha=5.)
         >>> g = u.atoms[8:12]
-        >>> g.atoms.positions=np.asarray([[.5,.5,6],[.5,.5,4],[.5,.5,-4],
+        >>> g.atoms.positions=np.asarray([[.5,.5,6],[.5,.5,4],[.5,.5,-4],\
                 [.5,.5,-6]])
         >>> print(pytim.observables.IntrinsicDistance(inter).compute(g))
         [ 1. -1. -1.  1.]

--- a/pytim/surface.py
+++ b/pytim/surface.py
@@ -281,8 +281,8 @@ class SurfaceFlatInterface(Surface):
         d2[np.where(d2 < -box / 2.)] += box
 
         cond = np.where(np.abs(d1) <= np.abs(d2))[0]
-        distance = lower_interp - positions[:, self.z]
-        distance[cond] = positions[cond][:, self.z] - upper_interp[cond]
+        distance = d2
+        distance[cond] = d1[cond]
 
         return distance
 

--- a/pytim/surface.py
+++ b/pytim/surface.py
@@ -282,7 +282,7 @@ class SurfaceFlatInterface(Surface):
 
         cond = np.where(np.abs(d1) <= np.abs(d2))[0]
         distance = d2
-        distance[cond] = d1[cond]
+        distance[cond] = -d1[cond]
 
         return distance
 

--- a/pytim/willard_chandler.py
+++ b/pytim/willard_chandler.py
@@ -8,6 +8,11 @@
 from __future__ import print_function
 import numpy as np
 from skimage import measure
+try:
+    marching_cubes = measure.marching_cubes
+except AttributeError:
+    marching_cubes =  measure.marching_cubes_lewiner
+
 
 from . import messages
 from . import utilities, vtk, cube, wavefront_obj
@@ -310,7 +315,7 @@ class WillardChandler(Interface):
         # (december 2003). DOI: 10.1080/10867651.2003.10487582
         volume = self.density_field.reshape(
             tuple(np.array(ngrid[::-1]).astype(int)))
-        verts, faces, normals, values = measure.marching_cubes(
+        verts, faces, normals, values = marching_cubes(
             volume, None, spacing=tuple(spacing))
         # note that len(normals) == len(verts): they are normals
         # at the vertices, and not normals of the faces


### PR DESCRIPTION
should fix #288 

a simple check:

    import pytim
    import numpy as np
    from pytim.datafiles import WATER_GRO
    import MDAnalysis as mda
    u = mda.Universe(WATER_GRO)
    u.atoms[:8].positions=np.array([[0.,0,5],[0,1,5],[1,0,5],[1,1,5],
                [0.,0.,-5.],[0,1,-5],[1,0,-5],[1,1,-5]])
    upper,lower=u.atoms[:4],u.atoms[4:8]
    inter = pytim.SimpleInterface(u,symmetry='planar', upper=upper,
                lower=lower,alpha=5.)
    g = u.atoms[8:12]
    g.atoms.positions=np.asarray([[.5,.5,6],[.5,.5,4],[.5,.5,-4],
                [.5,.5,-6]])
    print(pytim.observables.IntrinsicDistance(inter).compute(g))
        
    [ 1. -1. -1.  1.]
"""
