### PR TITLE
Update willard_chandler.py

### DIFF
--- a/pytim/willard_chandler.py
+++ b/pytim/willard_chandler.py
@@ -6,8 +6,10 @@
 """
 
 from __future__ import print_function
-import numpy as np
 from skimage import measure
+import numpy as np
+np.set_printoptions(legacy=False) # fixes problem with skimage
+
 try:
     marching_cubes = measure.marching_cubes
 except AttributeError:

--- a/pytim/willard_chandler.py
+++ b/pytim/willard_chandler.py
@@ -8,7 +8,7 @@
 from __future__ import print_function
 from skimage import measure
 import numpy as np
-np.set_printoptions(legacy=False) # fixes problem with skimage
+np.set_printoptions(legacy=False)  # fixes problem with skimage
 
 try:
     marching_cubes = measure.marching_cubes


### PR DESCRIPTION
`skimage` when imported in `willard_chandler.py` somehow triggers the legacy='1.13' printoption of `numpy`

a simple test (check it with `nosetest --with-doctest test.py` ) is
```
import skimage
class TEST(object):
    """
    >>> import numpy as np
    >>> print(np.arange(0.,3.))
    [0. 1. 2.]
    """
```

As a workaround, we set explicitly  `np.set_printoptions(legacy=False)` after importing `skimage`