### PR TITLE
Cleaned up pack_into_box()

### DIFF
--- a/pytim/interface.py
+++ b/pytim/interface.py
@@ -146,10 +146,7 @@ class Interface(object):
             self.symmetry = symmetry
 
     def _define_cluster_group(self):
-        try:
-            self.universe.atoms.pack_into_box(self.universe.dimensions[:3])
-        except ValueError:
-            self.universe.atoms.pack_into_box(self.universe.dimensions)
+        self.universe.atoms.pack_into_box()
         self.cluster_group = self.universe.atoms[:0]  # empty
         if (self.cluster_cut is not None):
             cluster_cut = float(self.cluster_cut[0])
@@ -341,11 +338,8 @@ class Interface(object):
         translation = [0, 0, 0]
         translation[normal] = box / 2.
         universe.atoms.positions += np.array(translation)
-        try:
-            universe.atoms.pack_into_box(universe.dimensions[:3])
-        except ValueError:
-            universe.atoms.pack_into_box(universe.dimensions)
-            
+        universe.atoms.pack_into_box()
+
     def _shift_positions_to_middle(self):
         Interface.shift_positions_to_middle(self.universe, self.normal)
 
@@ -363,10 +357,7 @@ class Interface(object):
                     Interface._center(group, xyz, halfbox_shift=False)
                 except ValueError:
                     pass
-            try:
-                group.universe.atoms.pack_into_box(group.universe.dimensions[:3])
-            except ValueError:
-                group.universe.atoms.pack_into_box(group.universe.dimensions)
+            group.universe.atoms.pack_into_box()
 
     def center(self, planar_to_origin=False):
         Interface.center_system(


### PR DESCRIPTION
MDA 0.17.0 and 0.18.0
    both pack_into_box() and pack_into_box(dimensions[:3]) are OK
MDA 0.19.1
    pack_into_box() is still fine, but now requires pack_into_box(dimensions)
    instead of dimensions[:3].

So pack_into_box() always works.