### PR TITLE
Fixed memory leak

### DIFF
--- a/pytim/surface.py
+++ b/pytim/surface.py
@@ -9,6 +9,7 @@ from scipy.interpolate import LinearNDInterpolator
 from . import utilities
 from . import messages
 from .observables import LocalReferenceFrame as LocalReferenceFrame
+import weakref
 
 
 class Surface(object):
@@ -26,7 +27,7 @@ class Surface(object):
     __metaclass__ = ABCMeta
 
     def __init__(self, interface, options=None):
-        self.interface = interface
+        self.interface = weakref.ref(interface)
         self.normal = interface.normal
         self.alpha = interface.alpha
         self.options = options

--- a/pytim/surface.py
+++ b/pytim/surface.py
@@ -27,7 +27,7 @@ class Surface(object):
     __metaclass__ = ABCMeta
 
     def __init__(self, interface, options=None):
-        self.interface = weakref.ref(interface)
+        self.interface = weakref.proxy(interface)
         self.normal = interface.normal
         self.alpha = interface.alpha
         self.options = options


### PR DESCRIPTION
When instantiating an analysis such as
interface = pytim.ITIM(...)
multiple times, a memory leak occured.
This commit fixes that using a weakref.

This is to produce the error:

```
import MDAnalysis as mda 
import pytim
from pytim.datafiles import *

u = mda.Universe(WATER_GRO)
for i in range(0,2000):
    print i
    interface = pytim.ITIM(u, alpha=2., max_layers=4, molecular=True)
```


Here is where the error was found in ITIM:

```
        for nlayer, layer in enumerate(self._layers[
                0]):  # TODO should this be moved out of assign_layers?
            self._surfaces[nlayer] = Surface(self, options={'layer': nlayer})
```
Which is the penultimate block in itim.py