### PR TITLE
Updated rst-s for backwards compatibility

### DIFF
--- a/docs/source/guessing_radii.rst
+++ b/docs/source/guessing_radii.rst
@@ -38,10 +38,10 @@ MDAnalysis_, and deal with atomtypes only through the :doc:`Pytim <quick>` inter
 As there is no specific information in the gromos input file regarding atomic types,  these are
 assigned by MDAnalysis_ using the first letter of the atom name.
 
->>> print u.residues[0].atoms.types
+>>> print (u.residues[0].atoms.types)
 ['M' 'O' 'H']
 
->>> print u.residues[0].atoms.names
+>>> print (u.residues[0].atoms.names)
 ['Me1' 'O2' 'H3']
 
 When the interface is initialized, :doc:`Pytim <quick>` searches by default for the best
@@ -73,7 +73,7 @@ and the radii as values. This database will override the standard one (new behav
 >>> u = mda.Universe(METHANOL_GRO)
 >>> mydict    = {'Me':1.6, 'O':1.5, 'H':0.0}
 >>> interface = pytim.ITIM(u,radii_dict=mydict)
->>> print u.residues[0].atoms.radii
+>>> print (u.residues[0].atoms.radii)
 [1.6 1.5 0. ]
 
 **Case 3: overriding the default match**
@@ -85,8 +85,8 @@ using the :py:func:`pytim_data.vdwradii()`  function:
 >>> # Load the radii database from the G43A1 forcefield
 >>> gromos = pytim_data.vdwradii(G43A1_TOP)
 >>> # check which types are available
->>> print gromos.keys()
-['CU1+', 'CDmso', 'OWT3', 'CA2+', 'FE', 'BR', 'MG2+', 'HC', 'OWT4', 'CL-', 'NL', 'CCl4', 'CLCl4', 'CL', 'NE', 'SDmso', 'CH1', 'NZ', 'CH3', 'CH4', 'ODmso', 'NR', 'NT', 'C', 'HChl', 'DUM', 'F', 'H', 'CChl', 'CMet', 'CLChl', 'O', 'N', 'MW', 'P', 'S', 'AR', 'IW', 'CU2+', 'OM', 'CR1', 'MNH3', 'NA+', 'OA', 'SI', 'CH2', 'OW', 'ZN2+', 'OMet']
+>>> print (sorted(list(gromos.keys())))
+['AR', 'BR', 'C', 'CA2+', 'CChl', 'CCl4', 'CDmso', 'CH1', 'CH2', 'CH3', 'CH4', 'CL', 'CL-', 'CLChl', 'CLCl4', 'CMet', 'CR1', 'CU1+', 'CU2+', 'DUM', 'F', 'FE', 'H', 'HC', 'HChl', 'IW', 'MG2+', 'MNH3', 'MW', 'N', 'NA+', 'NE', 'NL', 'NR', 'NT', 'NZ', 'O', 'OA', 'ODmso', 'OM', 'OMet', 'OW', 'OWT3', 'OWT4', 'P', 'S', 'SDmso', 'SI', 'ZN2+']
 
 In some cases, the automated procedure does not yield the expected
 (or wanted) match.  To fix this one can just update the database

--- a/docs/source/micelle.rst
+++ b/docs/source/micelle.rst
@@ -71,7 +71,7 @@ Some statistics
 
 It's easy to calculate some simple statistical properties. For example, the percentage of atoms of DPC at the surface is
 
-    >>> print "percentage of atoms at the surface: {:.1f}".format(len(inter.layers[0])*100./len(g))
+    >>> print ("percentage of atoms at the surface: {:.1f}".format(len(inter.layers[0])*100./len(g)))
     percentage of atoms at the surface: 47.2
 
 This is a rather high percentage, but is due to the small size of the micelle (large surface/volume ratio)
@@ -82,7 +82,7 @@ We can also easily find out which atom is more likely to be found at the surface
     >>> for name in g.residues[0].atoms.names :
     ...     total   = np.sum(g.names==name)
     ...     surface = np.sum(inter.layers[0].names == name )
-    ...     print('{:>4s} ---> {:>2.0f}%'.format(name, surface*100./total))
+    ...     print ('{:>4s} ---> {:>2.0f}%'.format(name, surface*100./total))
       C1 ---> 97%
       C2 ---> 95%
       C3 ---> 100%

--- a/docs/source/newproperties.rst
+++ b/docs/source/newproperties.rst
@@ -38,7 +38,7 @@ The value of :py:obj:`atoms.layers` can be either -1 (atom not in any of the lay
     >>> u = mda.Universe(WATER_GRO)
     >>> g = u.select_atoms('name OW')
     >>> inter = pytim.ITIM(u,group=g,max_layers=3)
-    >>> print np.unique(u.atoms.layers)
+    >>> print (np.unique(u.atoms.layers))
     [-1  1  2  3]
 
 This property can be used to select a particular subset of atoms, e.g.

--- a/docs/source/quick.rst
+++ b/docs/source/quick.rst
@@ -88,7 +88,7 @@ We make here the example of multiple solvation layers around glucose:
     inter = pytim.GITIM(u, group=solvent, max_layers=3, alpha=2)
 
     for i in [0,1,2]:
-        print "Layer "+str(i),repr(inter.layers[i])
+        print ("Layer "+str(i),repr(inter.layers[i]))
 
     Layer 0 <AtomGroup with 54 atoms>
     Layer 1 <AtomGroup with 117 atoms>

--- a/pytim/sanity_check.py
+++ b/pytim/sanity_check.py
@@ -171,7 +171,7 @@ class SanityCheck(object):
                 print("You can override this by using, e.g.: pytim.", end='')
                 print(self.interface.__class__.__name__, end=' ')
                 print("(u,radii_dict={ '", end='')
-                print(gr.keys()[0] + "':1.2 , ... } )")
+                print(list(gr.keys())[0] + "':1.2 , ... } )")
         except BaseException:
             pass
 


### PR DESCRIPTION
The rst files in the documention use parentheses for printing.
The printing of a dictionary in sanity_check conforms to python3.