### PR TITLE
GITIM only working with MDAnalysis. Changed data type for self._layer…

### DIFF
--- a/pytim/gitim.py
+++ b/pytim/gitim.py
@@ -140,7 +140,7 @@ J. Chem. Phys. 138, 044110, 2013)*
         sanity.assign_alpha(alpha)
 
         self.max_layers = max_layers
-        self._layers = np.empty([max_layers], dtype=type(universe.atoms))
+        self._layers = np.empty([max_layers], dtype=self.universe.atoms[0].__class__)
         self.info = info
         self.normal = None
         self.PDB = {}

--- a/pytim/gitim.py
+++ b/pytim/gitim.py
@@ -140,7 +140,7 @@ J. Chem. Phys. 138, 044110, 2013)*
         sanity.assign_alpha(alpha)
 
         self.max_layers = max_layers
-        self._layers = np.empty([max_layers], dtype=self.universe.atoms[0].__class__)
+        self._layers = np.empty([max_layers], dtype=type(self.universe.atoms))
         self.info = info
         self.normal = None
         self.PDB = {}


### PR DESCRIPTION
GITIM only working with MDAnalysis. Changed data type for self._layers in GITIM from type(universe.atoms) to self.universe.atoms[0].__class__, which is the same as in ITIM. This does not appear to break anything. At least the DPC micelle example with MDAnalysis gives the same number of interfacial atoms after the fix and an mdtraj version of the DPC micelle example also gives the same number of interfacial atoms after the fix. Here is the mdtraj version of the DPC micelle example:

```python
import mdtraj
import pytim
from   pytim.datafiles import *

t = mdtraj.load_pdb(MICELLE_PDB)
g = t.top.select("resname=='DPC'")

interface = pytim.GITIM(t, group=g, molecular=False, symmetry='spherical', alpha=2.5)
layer = interface.layers[0]
print repr(layer)
```