### PR TITLE
patch for replacement tables

### DIFF
--- a/pytim/__init__.py
+++ b/pytim/__init__.py
@@ -2,8 +2,9 @@
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 #from pytim.patches import patchTrajectory, patchOpenMM, patchMDTRAJ
 
-from .patches import patchNumpy
+from .patches import patchNumpy, patchMDTRAJ_ReplacementTables
 patchNumpy()
+patchMDTRAJ_ReplacementTables()
 import warnings
 from .version import __version__
 from . import observables, utilities, datafiles

--- a/pytim/itim.py
+++ b/pytim/itim.py
@@ -240,8 +240,8 @@ J. Comp. Chem. 29, 945, 2008)*
         self.mesh_dx = d[0]
         self.mesh_dy = d[1]
 
-        _x = np.linspace(0, box[0], num=self.mesh_nx, endpoint=False)
-        _y = np.linspace(0, box[1], num=self.mesh_ny, endpoint=False)
+        _x = np.linspace(0, box[0], num=int(self.mesh_nx), endpoint=False)
+        _y = np.linspace(0, box[1], num=int(self.mesh_ny), endpoint=False)
         _X, _Y = np.meshgrid(_x, _y)
         self.meshpoints = np.array([_X.ravel(), _Y.ravel()]).T
         self.meshtree = cKDTree(self.meshpoints, boxsize=box[:2])


### PR DESCRIPTION
Partially fixes a problem (#320) with standard atom names replacement in MDTraj. 

If pytim is imported *before* loading a trajectory with MDTraj, the atom names replacement is suppressed, and the atom names appearing in the topology are those read from, e.g., the PDB or GRO file. If, however, the trajectory is first loaded with MDTraj, and only then pytim is imported, the atom names will still be replaced. Should be a problem (unexpected behavior) only in a small number of cases, as users tend to import modules first. 