### PR TITLE
Reorganized GITIM's alpha_shape()

### DIFF
--- a/pytim/gitim.py
+++ b/pytim/gitim.py
@@ -184,8 +184,8 @@ J. Chem. Phys. 138, 044110, 2013)*
         points = group.positions[:]
         nrealpoints = len(points)
 
-        # The Delaunay tessellation does not handle periodic boundary conditions,
-        # thus one has to physically copy a layer of atoms of a thickness, delta
+        # Delaunay tessellation does not handle periodic boundary conditions,
+        # have to physically copy a layer of atoms of a thickness, delta
         if self._noextrapoints is False:
             box = self.universe.dimensions[:3]
             delta = np.array([self._buffer_factor * self.alpha] * 3)
@@ -212,9 +212,9 @@ J. Chem. Phys. 138, 044110, 2013)*
         radii = np.append(group.radii[extraids[extraids >= 0]],
                           np.zeros(8))
 
-        _points = triangulation.points  # simply using extrapoints results in
-                                        # buffer mismatch (npreal vs float)
-                                        # in circumradius()
+        # simply using extrapoints results in buffer dtype mismatch
+        # in circumradius()
+        _points = triangulation.points
 
         cr = circumradius(_points, radii, simplices)
         # we filter first according to the touching sphere radius

--- a/pytim/gitim.py
+++ b/pytim/gitim.py
@@ -212,11 +212,15 @@ J. Chem. Phys. 138, 044110, 2013)*
         radii = np.append(group.radii[extraids[extraids >= 0]],
                           np.zeros(8))
 
-        cr = circumradius(extrapoints, radii, simplices)
+        _points = triangulation.points  # simply using extrapoints results in
+                                        # buffer mismatch (npreal vs float)
+                                        # in circumradius()
+
+        cr = circumradius(_points, radii, simplices)
         # we filter first according to the touching sphere radius
         a_shape = simplices[cr >= self.alpha]
         # then we remove all simplices involving the 8 outer points, if any
-        cond = np.where(np.all(a_shape < len(extrapoints) - n_cube, axis=1))[0]
+        cond = np.where(np.all(a_shape < len(_points) - n_cube, axis=1))[0]
         a_shape = a_shape[np.unique(cond)]
         # finally, we select only the ids of atoms in the basic cell.
         return np.unique(a_shape[np.where(a_shape < nrealpoints)])


### PR DESCRIPTION
Further reorganization of GITIM, eliminating the superfluous try-except blocks and simplifying
the alpha_shape function. 