### PR TITLE
flipped x and z axes in marching_cubes output for consistency

### DIFF
--- a/pytim/vtk.py
+++ b/pytim/vtk.py
@@ -95,7 +95,7 @@ class Writevtk(object):
         vertices, faces, normals = list(inter.triangulated_surface[0:3])
         if sequence is True:
             filename = consecutive_filename(inter.universe, filename)
-        write_triangulation(filename, vertices[::, ::-1], faces, normals)
+        write_triangulation(filename, vertices, faces, normals)
 
 
 def _format_vector(vector, format_str="{:f}"):

--- a/pytim/willard_chandler.py
+++ b/pytim/willard_chandler.py
@@ -226,6 +226,7 @@ class WillardChandler(Interface):
             volume, None, spacing=tuple(spacing))
         # note that len(normals) == len(verts): they are normals
         # at the vertices, and not normals of the faces
-        self.triangulated_surface = [verts, faces, normals]
+        # verts and normals have x and z flipped because skimage uses zyx ordering
+        self.triangulated_surface = [np.fliplr(verts), faces, np.fliplr(normals)]
         self.surface_area = measure.mesh_surface_area(verts, faces)
         verts += spacing[::-1] / 2.


### PR DESCRIPTION
The surface data outputted by Writevtk.surface contained normal vectors whose x and z axes were flipped relative to the ordering used for the surface vertices, leading to normals appearing not to be normal to the surface in visualization.

The underlying cause of this problem seems to lie in the marching_cubes_lewiner function from skimage, in which the axes are flipped for both vertices and normals because (according to a comment in the code) "skimage uses zyx ordering"...

Fixed by flipping the axes back after the call to marching_cubes.