### PR TITLE
Expose `normalize` option to `writecube`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,195 @@
+# Created by https://www.toptal.com/developers/gitignore/api/python,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,visualstudiocode
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/python,visualstudiocode

--- a/pytim/gaussian_kde_pbc.py
+++ b/pytim/gaussian_kde_pbc.py
@@ -3,33 +3,88 @@
 """ Module: pytim.gaussian_kde_pbc
     ==============================
 """
-from __future__ import print_function
 import numpy as np
-from scipy.stats import gaussian_kde
-from scipy.spatial import cKDTree
+
+try:
+    from jax.scipy.stats import gaussian_kde
+    has_jax = True
+except ImportError:
+    from scipy.spatial import cKDTree
+    from scipy.stats import gaussian_kde
+    has_jax = False
+
+def make_supercell_images(pos, box, n_images=1):
+    """ Generate supercell images of a set of points
+
+        :param np.ndarray pos:  positions of the points
+        :param np.ndarray box:  box dimensions
+        :param int n_images:    number of images to generate
+
+    """
+    images = []
+    for i in range(-n_images, n_images + 1):
+        for j in range(-n_images, n_images + 1):
+            for k in range(-n_images, n_images + 1):
+                images.append(pos + np.array([i, j, k]) * box)
+    return np.vstack(images)
 
 
 class gaussian_kde_pbc(gaussian_kde):
     # note that here "points" are those on the grid
 
-    def evaluate_pbc_fast(self, points):
-        grid = points
-        pos = self.pos
-        box = self.box
-        d = self.sigma * 2.5
-        results = np.zeros(grid.shape[1], dtype=float)
-        gridT = grid[::-1].T[:]
-        tree = cKDTree(gridT, boxsize=box)
-        # the indices of grid elements within distane d from each of the pos
-        scale = 2. * self.sigma**2
-        indlist = tree.query_ball_point(pos, d)
-        for n, ind in enumerate(indlist):
-            dr = gridT[ind, :] - pos[n]
-            cond = np.where(dr > box / 2.)
-            dr[cond] -= box[cond[1]]
-            cond = np.where(dr < -box / 2.)
-            dr[cond] += box[cond[1]]
-            dens = np.exp(-np.sum(dr * dr, axis=1) / scale)
-            results[ind] += dens
+    def __init__(self, pos, box, sigma, weights=None):
+        """ Initialize the gaussian_kde_pbc object.
+        
+        :param ndarray pos: the particle positions.
+        :param ndarray box: the box dimensions.
+        :param float sigma: the sigma value.
+        :param ndarray weights: the weights of the points in the dataset.
 
-        return results
+        """
+        self.box = box
+        self.pos = pos
+        self.sigma = sigma
+
+        dataset = np.vstack([pos[::, 0], pos[::, 1], pos[::, 2]])
+
+        if has_jax:
+            supercell = make_supercell_images(pos, box=box)
+            dataset = np.vstack([supercell[::, 0], supercell[::, 1], supercell[::, 2]])
+
+        self.stddev = dataset.std(ddof=1)
+        bw_method = sigma / self.stddev
+
+        super().__init__(dataset, bw_method=bw_method, weights=weights)
+
+    def evaluate(self, points):
+        """ Evaluate the estimated pdf on a set of points.
+
+        :param ndarray points: the points where the pdf is to be evaluated.
+        :return: the value of the estimated pdf at the points.
+        :rtype: ndarray
+
+        """
+        if has_jax:
+            return np.array(super().evaluate(points))
+
+        else:
+            grid = points
+            pos = self.pos
+            box = self.box
+            d = self.sigma * 2.5
+            results = np.zeros(grid.shape[1], dtype=float)
+            gridT = grid[::-1].T[:]
+            tree = cKDTree(gridT, boxsize=box)
+            # the indices of grid elements within distane d from each of the pos
+            scale = 2. * self.sigma**2
+            indlist = tree.query_ball_point(pos, d)
+            for n, ind in enumerate(indlist):
+                dr = gridT[ind, :] - pos[n]
+                cond = np.where(dr > box / 2.)
+                dr[cond] -= box[cond[1]]
+                cond = np.where(dr < -box / 2.)
+                dr[cond] += box[cond[1]]
+                dens = np.exp(-np.sum(dr * dr, axis=1) / scale)
+                results[ind] += dens
+
+            return results

--- a/pytim/utilities.py
+++ b/pytim/utilities.py
@@ -5,25 +5,29 @@
     =================
 """
 from __future__ import print_function
-from timeit import default_timer as timer
-from itertools import product
-import numpy as np
-from sys import stderr
 
+from itertools import product
+from sys import stderr
+from timeit import default_timer as timer
+
+import numpy as np
 from MDAnalysis.core.groups import Atom, AtomGroup, Residue, ResidueGroup
 
-from .utilities_geometry import trim_triangulated_surface
-from .utilities_geometry import triangulated_surface_stats
-from .utilities_geometry import polygonalArea, fit_sphere, EulerRotation
-from .utilities_geometry import find_surface_triangulation
-from .utilities_geometry import pbc_compact, pbc_wrap
-from .utilities_pbc import generate_periodic_border, rebox
+from .atoms_maps import atoms_maps
 from .gaussian_kde_pbc import gaussian_kde_pbc
 from .utilities_dbscan import do_cluster_analysis_dbscan
-
-from .atoms_maps import atoms_maps
-from .utilities_mesh import compute_compatible_mesh_params
-from .utilities_mesh import generate_grid_in_box
+from .utilities_geometry import (
+    EulerRotation,
+    find_surface_triangulation,
+    fit_sphere,
+    pbc_compact,
+    pbc_wrap,
+    polygonalArea,
+    triangulated_surface_stats,
+    trim_triangulated_surface,
+)
+from .utilities_mesh import compute_compatible_mesh_params, generate_grid_in_box
+from .utilities_pbc import generate_periodic_border, rebox
 
 
 def lap(show=False):
@@ -244,12 +248,8 @@ def guess_normal(universe, group):
 
 
 def density_map(pos, grid, sigma, box):
-    values = np.vstack([pos[::, 0], pos[::, 1], pos[::, 2]])
-    kernel = gaussian_kde_pbc(values, bw_method=sigma / values.std(ddof=1))
-    kernel.box = box
-    kernel.sigma = sigma
-    return kernel, values.std(ddof=1)
-
+    kernel = gaussian_kde_pbc(pos, box=box, sigma=sigma)
+    return kernel, kernel.stddev
 
 def _NN_query(kdtree, position, qrange):
     return kdtree.query_ball_point(position, qrange, n_jobs=-1)
@@ -283,5 +283,3 @@ def generate_cube_vertices(box, delta=0.0, jitter=False, dim=3):
         np.random.set_state(state)
 
     return vertices
-
-#

--- a/pytim/willard_chandler.py
+++ b/pytim/willard_chandler.py
@@ -6,23 +6,18 @@
 """
 
 from __future__ import print_function
-from skimage import measure
-import numpy as np
 
-from . import messages
-from . import utilities, cube, wavefront_obj
+import numpy as np
+from skimage import measure
+from skimage.measure import marching_cubes
+
+from . import cube, messages, utilities, wavefront_obj
+from .interface import Interface
+from .patches import patchMDTRAJ, patchOpenMM, patchTrajectory
 from .sanity_check import SanityCheck
 from .vtk import Writevtk
 
-from .interface import Interface
-from .patches import patchTrajectory, patchOpenMM, patchMDTRAJ
-
 np.set_printoptions(legacy=False)  # fixes problem with skimage
-
-try:
-    marching_cubes = measure.marching_cubes
-except AttributeError:
-    marching_cubes = measure.marching_cubes_lewiner
 
 
 class WillardChandler(Interface):
@@ -243,8 +238,7 @@ class WillardChandler(Interface):
         grid = utilities.generate_grid_in_box(box, ngrid, order='xyz')
         kernel, _ = utilities.density_map(pos, grid, self.alpha, box)
 
-        kernel.pos = pos.copy()
-        self.density_field = kernel.evaluate_pbc_fast(grid)
+        self.density_field = kernel.evaluate(grid)
 
         # Thomas Lewiner, Helio Lopes, Antonio Wilson Vieira and Geovan
         # Tavares. Efficient implementation of Marching Cubes’ cases with

--- a/pytim/willard_chandler.py
+++ b/pytim/willard_chandler.py
@@ -156,13 +156,14 @@ class WillardChandler(Interface):
         self._atoms = self._layers[:]  # this is an empty AtomGroup
         self.writevtk = Writevtk(self)
 
-    def writecube(self, filename="pytim.cube", group=None, sequence=False):
+    def writecube(self, filename="pytim.cube", group=None, sequence=False, normalize=True):
         """ Write to cube files (sequences) the volumentric density and the
             atomic positions.
 
             :param str filename:  the file name
             :param bool sequence: if true writes a sequence of files adding
                                   the frame to the filename
+            :param bool normalize: if true normalizes the density field to [0, 1]
 
             >>> import MDAnalysis as mda
             >>> import pytim
@@ -173,6 +174,7 @@ class WillardChandler(Interface):
             >>> inter.writecube('dens.cube') # writes on dens.cube
             >>> inter.writecube('dens.cube',group=g) # writes also  particles
             >>> inter.writecube('dens.cube',sequence=True) # dens.<frame>.cube
+            >>> inter.writecube('dens.cube', normalize=False) # writes density values without normalization
         """
         if sequence is True:
             filename = cube.consecutive_filename(self.universe, filename)
@@ -183,7 +185,8 @@ class WillardChandler(Interface):
             self.ngrid,
             self.spacing,
             self.density_field,
-            atomic_numbers=None)
+            atomic_numbers=None,
+            normalize=normalize)
 
     def writeobj(self, filename="pytim.obj", sequence=False):
         """ Write to wavefront obj files (sequences) the triangulated surface


### PR DESCRIPTION
#### If you have written a new method in one of the available modules

  - [x] Document it with a docstring
  - [x] Add a short, deterministic test in the docstring 
  - [x] Explain briefly what the patch is about in the pull request

My last contribution let the user define a density cutoff for their Willard-Chandler surfaces. When I was trying to find the right one for my systems, I noticed that pytim normalises the calculated density field by default when writing to a cube. This just exposes the `normalize` flag to the `WillardChandler.writecube()` method so you can disable that behaviour -- makes it much easier to find the right values in visualisation software.