### PR TITLE
integrating pytim-notebooks

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,6 +58,8 @@ jobs:
         cd pytim-notebooks
         IFS=$(echo -ne "\n\b") ; 
         for notebook in $(find . -name "*.ipynb"); do
+          base=$(basename "$notebook" .ipynb)
+          output="executed_${base}.ipynb"
           echo "Running $notebook"
-          jupyter nbconvert --to notebook --execute "$notebook" --output /dev/null
+          jupyter nbconvert --to notebook --execute "$notebook" --output "$output"
         done


### PR DESCRIPTION
This revision adds pytim-notebooks to the CI workflow.
The repository https://github.com/Marcello-Sega/pytim-notebooks is cloned and the notebooks are executed